### PR TITLE
Add missing default.tsx files for parallel route slots

### DIFF
--- a/src/app/dashboard/@lms_admin/default.tsx
+++ b/src/app/dashboard/@lms_admin/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/src/app/dashboard/@org_admin/default.tsx
+++ b/src/app/dashboard/@org_admin/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/src/app/dashboard/@super_admin/default.tsx
+++ b/src/app/dashboard/@super_admin/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}


### PR DESCRIPTION
Next.js parallel routes require default.tsx in each slot to handle unmatched route segments. Without these, navigating to any sub-route causes the entire page to fail because slots without a matching segment cannot resolve. Added default.tsx returning null to @super_admin, @lms_admin, and @org_admin slots.

https://claude.ai/code/session_01SC1b8MQuxedfJebyopteX2