### PR TITLE
Fix blank dashboard: add auth fallback, error boundary, and Weglot guard

### DIFF
--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex h-[calc(100vh-64px)] flex-col items-center justify-center gap-4 w-full">
+      <h1 className="text-2xl font-bold text-destructive">
+        Something went wrong loading the dashboard
+      </h1>
+      <p className="text-muted-foreground">{error.message}</p>
+      <Button onClick={() => reset()}>Try again</Button>
+    </div>
+  );
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,6 +1,7 @@
 import { fetchUserData } from '@/action/authAction';
 import InactiveEmail from '@/components/InactiveEmail';
 import { Toaster } from '@/components/ui/sonner';
+import { createClient } from '@/utils/supabase/server';
 
 export default async function Layout({
   children,
@@ -15,9 +16,39 @@ export default async function Layout({
   org_admin: React.ReactNode;
   super_admin: React.ReactNode;
 }) {
-  const userData = await fetchUserData();
-  const user_role = userData?.user_role;
-  const is_active = userData?.is_active;
+  // First verify user is authenticated
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    return null;
+  }
+
+  // Fetch user role - try RPC first, fallback to direct query
+  let user_role: string | null = null;
+  let is_active = false;
+
+  try {
+    const userData = await fetchUserData();
+    user_role = userData?.user_role ?? null;
+    is_active = userData?.is_active ?? false;
+  } catch (error) {
+    console.error('fetchUserData RPC failed, trying direct query:', error);
+  }
+
+  // Fallback: query users table directly if RPC failed
+  if (!user_role) {
+    const { data: userRecord } = await supabase
+      .from('users')
+      .select('role, is_active')
+      .eq('id', user.id)
+      .single();
+
+    if (userRecord) {
+      user_role = userRecord.role;
+      is_active = userRecord.is_active ?? false;
+    }
+  }
 
   if (!user_role) {
     return null;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -111,10 +111,16 @@ export default async function RootLayout({
         <Script strategy="beforeInteractive" src="https://player.vimeo.com/api/player.js" />
         <Script id="Weglot" strategy="beforeInteractive">
           {`setTimeout(() => {
-            Weglot.initialize({
-              api_key: "wg_6ed8ff3cee7ad29ea2def8ac2f08adfa8",
-              hide_switcher: true,
-            });
+            try {
+              if (typeof Weglot !== 'undefined') {
+                Weglot.initialize({
+                  api_key: "wg_6ed8ff3cee7ad29ea2def8ac2f08adfa8",
+                  hide_switcher: true,
+                });
+              }
+            } catch (e) {
+              console.warn('Weglot initialization failed:', e);
+            }
           }, 400)`}
         </Script>
       </head>


### PR DESCRIPTION
Dashboard layout now:
- Verifies auth with supabase.auth.getUser() first
- Tries fetchUserData() RPC, then falls back to direct users table query if RPC fails (same approach the working Navbar uses)
- Has a proper error.tsx error boundary to show errors instead of blank pages

Root layout:
- Wraps Weglot.initialize() in try/catch with typeof check to prevent uncaught errors when CDN returns 403

https://claude.ai/code/session_01SC1b8MQuxedfJebyopteX2