### PR TITLE
Enhance admin dashboard: trends, responsive fonts, quiz tab, pie char…

### DIFF
--- a/src/action/lms-admin/insights/courses/coursesAction.ts
+++ b/src/action/lms-admin/insights/courses/coursesAction.ts
@@ -53,6 +53,27 @@ export const fetchAllCourses = async (page: number, pageSize: number, filters: a
     }
 }
 
+export const fetchCourseStatusCounts = async () => {
+    const supabase = await createClient();
+    try {
+        const { data, error } = await supabase.rpc('get_all_courses', {
+            _name_filter: null,
+            _category_filter: null,
+            _status_filter: null,
+        });
+        if (error) throw error;
+        const counts: Record<string, number> = {};
+        for (const course of data || []) {
+            const status = course.status || 'Unknown';
+            counts[status] = (counts[status] || 0) + 1;
+        }
+        return Object.entries(counts).map(([name, value]) => ({ name, value }));
+    } catch (error: any) {
+        console.error('Error fetching course status counts:', error.message);
+        return [];
+    }
+};
+
 export const exportCourses = async () => {
     const supabase = await createClient();
     const { data, error } = await supabase.rpc('get_all_courses', {

--- a/src/app/dashboard/@lms_admin/insights/CardStatus.tsx
+++ b/src/app/dashboard/@lms_admin/insights/CardStatus.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react'
 import { ReactNode } from 'react'
 
 interface CardStatusProps {
@@ -13,7 +14,8 @@ interface CardStatusProps {
 function CardStatus({ title, icon, number, percent, loading }: CardStatusProps) {
   const formattedNumber = number ?? 0
   const formattedPercent = typeof percent === 'number' ? percent : 'N/A'
-  const isPositive = typeof formattedPercent === 'number' && formattedPercent >= 0
+  const isPositive = typeof formattedPercent === 'number' && formattedPercent > 0
+  const isNegative = typeof formattedPercent === 'number' && formattedPercent < 0
 
   if (loading) {
     return <CardSkeleton />
@@ -22,20 +24,37 @@ function CardStatus({ title, icon, number, percent, loading }: CardStatusProps) 
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between pb-2">
-        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        <CardTitle className="text-xs sm:text-sm font-medium">{title}</CardTitle>
         <div aria-label={`${title} icon`} role="img">
           {icon}
         </div>
       </CardHeader>
       <CardContent>
-        <div className="text-2xl font-bold">
-          {title === 'Average Completion Rate' ? `${formattedNumber}%` : formattedNumber}
+        <div className="text-lg sm:text-xl md:text-2xl font-bold">
+          {title === 'Average Completion Rate' ? `${formattedNumber}%` : formattedNumber.toLocaleString()}
         </div>
         {percent !== null && (
-          <p className="text-xs text-muted-foreground">
-            {formattedPercent !== 'N/A'
-              ? `${isPositive ? '+' : ''}${formattedPercent} from last month`
-              : 'No data available from last month'}
+          <p className={`text-xs flex items-center gap-1 mt-1 ${
+            isPositive
+              ? 'text-green-600'
+              : isNegative
+                ? 'text-red-600'
+                : 'text-muted-foreground'
+          }`}>
+            {formattedPercent !== 'N/A' ? (
+              <>
+                {isPositive ? (
+                  <TrendingUp className="h-3.5 w-3.5" />
+                ) : isNegative ? (
+                  <TrendingDown className="h-3.5 w-3.5" />
+                ) : (
+                  <Minus className="h-3.5 w-3.5" />
+                )}
+                {isPositive ? '+' : ''}{formattedPercent} from last month
+              </>
+            ) : (
+              'No data available from last month'
+            )}
           </p>
         )}
       </CardContent>

--- a/src/app/dashboard/@lms_admin/insights/completions/CompletionsDataTable.tsx
+++ b/src/app/dashboard/@lms_admin/insights/completions/CompletionsDataTable.tsx
@@ -5,11 +5,14 @@ import CompletionsFilter from './CompletionsFilter';
 import { Student } from './type';
 import { DataTableComponent } from '@/components/DataTable';
 import { TableControls } from '@/components/shared/TableControls';
+import { Card, CardContent } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { Download } from 'lucide-react';
 import { exportToExcel } from '@/utils/exportExcel';
 import { getAllCompletions } from '@/action/lms-admin/insights/completions/completionsActions';
+import Link from 'next/link';
 
 
 function CompletionsDataTable({  completionsData, count , currentPage , pageSize }: { completionsData: Student[], count: number, currentPage: number, pageSize: number }) {
@@ -59,6 +62,43 @@ function CompletionsDataTable({  completionsData, count , currentPage , pageSize
           >
             {exportLoading ? 'Exporting...' : 'Export'} <Download className="ms-2 h-4 w-4" />
           </Button>
+        )}
+        renderMobileCard={(row: Student) => (
+          <Card key={row.enrollment_id}>
+            <CardContent className="p-4 space-y-2">
+              <div className="flex items-center justify-between">
+                <div className="min-w-0">
+                  <p className="font-semibold text-sm truncate exclude-weglot">{row.name}</p>
+                  <p className="text-xs text-muted-foreground truncate">{row.email}</p>
+                </div>
+              </div>
+              <div className="text-xs space-y-1">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Course</span>
+                  <span className="font-medium text-right truncate max-w-[60%] exclude-weglot">{row.course}</span>
+                </div>
+                {row.department && (
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Department</span>
+                    <span className="font-medium exclude-weglot">{row.department}</span>
+                  </div>
+                )}
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Completed</span>
+                  <span className="font-medium">{new Date(row.completion_date).toLocaleDateString()}</span>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Progress value={row.progress_percentage} className="h-2 flex-1" />
+                <span className="text-xs font-medium shrink-0">{row.progress_percentage}%</span>
+              </div>
+              <Link href={`/dashboard/insights/completions/${row.course_id}?user_id=${row.user_id}`}>
+                <Button size="sm" variant="outline" className="w-full mt-1">
+                  Show Details
+                </Button>
+              </Link>
+            </CardContent>
+          </Card>
         )}
       />
     </>

--- a/src/app/dashboard/@lms_admin/insights/courses/CoruseTable.tsx
+++ b/src/app/dashboard/@lms_admin/insights/courses/CoruseTable.tsx
@@ -7,16 +7,21 @@ import { DataTableComponent } from '@/components/DataTable';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
 import { Download } from 'lucide-react';
 import { exportCourses } from '@/action/lms-admin/insights/courses/coursesAction';
 import { exportToExcel } from '@/utils/exportExcel';
+import Image from 'next/image';
+import Link from 'next/link';
+import { InsightsCourseColumnsProps } from './type';
 
 
 
 function CourseTable({ courses, count, currentPage, pageSize }: { courses: any, count?: number, currentPage?: number, pageSize?: number }) {
     const router = useRouter()
     const [exportLoading, setExportLoading] = useState(false)
-    
+
     const handlePageChange = (newPage: number) => {
         const searchParams = new URLSearchParams(window.location.search)
         searchParams.set('page', newPage.toString())
@@ -35,7 +40,7 @@ function CourseTable({ courses, count, currentPage, pageSize }: { courses: any, 
         }
         setExportLoading(false)
     }
-    
+
     return (
         <DataTableComponent
             columns={columns}
@@ -52,7 +57,7 @@ function CourseTable({ courses, count, currentPage, pageSize }: { courses: any, 
                 />
             )}
             actionTable={() => (
-                <Button 
+                <Button
                     variant="outline"
                     className='w-full md:w-fit'
                     onClick={handleExport}
@@ -60,6 +65,53 @@ function CourseTable({ courses, count, currentPage, pageSize }: { courses: any, 
                 >
                     {exportLoading ? 'Exporting...' : 'Export'} <Download className="ms-2 h-4 w-4" />
                 </Button>
+            )}
+            renderMobileCard={(row: InsightsCourseColumnsProps) => (
+                <Card key={row.course_id}>
+                    <CardContent className="p-4">
+                        <div className="flex gap-3 mb-3">
+                            {row.thumbnail && (
+                                <Image
+                                    src={row.thumbnail}
+                                    alt={row.name}
+                                    width={64}
+                                    height={64}
+                                    className="h-16 w-16 rounded object-cover shrink-0"
+                                />
+                            )}
+                            <div className="min-w-0">
+                                <p className="font-semibold text-sm truncate exclude-weglot">{row.name}</p>
+                                <p className="text-xs text-muted-foreground exclude-weglot">{row.category}</p>
+                                <Badge className="mt-1" variant={row.status === "Published" ? "default" : "outline"}>
+                                    {row.status}
+                                </Badge>
+                            </div>
+                        </div>
+                        <div className="grid grid-cols-2 gap-2 text-xs mb-3">
+                            <div>
+                                <span className="text-muted-foreground">Enrollments: </span>
+                                <span className="font-medium">{row.enrollments}</span>
+                            </div>
+                            <div>
+                                <span className="text-muted-foreground">Completions: </span>
+                                <span className="font-medium">{row.completions}</span>
+                            </div>
+                            <div>
+                                <span className="text-muted-foreground">Created: </span>
+                                <span className="font-medium">{new Date(row.created_at).toLocaleDateString()}</span>
+                            </div>
+                            <div>
+                                <span className="text-muted-foreground">By: </span>
+                                <span className="font-medium exclude-weglot">{row.created_by_name}</span>
+                            </div>
+                        </div>
+                        <Link href={`/dashboard/insights/courses/${row.course_id}`}>
+                            <Button size="sm" variant="outline" className="w-full">
+                                View Details
+                            </Button>
+                        </Link>
+                    </CardContent>
+                </Card>
             )}
         />
     )

--- a/src/app/dashboard/@lms_admin/insights/courses/InsightsCourse.tsx
+++ b/src/app/dashboard/@lms_admin/insights/courses/InsightsCourse.tsx
@@ -91,6 +91,61 @@ const BarChartCard = ({
   </Card>
 );
 
+const STATUS_COLORS: Record<string, string> = {
+  Published: '#4BB543',
+  Draft: '#F59E0B',
+  Archived: '#9CA3AF',
+};
+
+const CourseStatusPieChart = ({ data }: { data: { name: string; value: number }[] }) => {
+  if (!data || data.length === 0) return null;
+
+  const colors = data.map((d) => STATUS_COLORS[d.name] || '#8884d8');
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>Course Status Distribution</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="h-[200px]">
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={data}
+                cx="50%"
+                cy="50%"
+                labelLine={false}
+                outerRadius={80}
+                fill="#8884d8"
+                dataKey="value"
+              >
+                {data.map((entry, index) => (
+                  <Cell key={`status-${index}`} fill={colors[index]} />
+                ))}
+              </Pie>
+              <Tooltip />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+        <div className="flex flex-wrap justify-center gap-3 mt-4">
+          {data.map((entry, index) => (
+            <div key={`status-legend-${index}`} className="flex items-center gap-1.5">
+              <div
+                className="h-3 w-3 rounded-full"
+                style={{ backgroundColor: colors[index] }}
+              />
+              <span className="text-xs sm:text-sm">
+                {entry.name} ({entry.value})
+              </span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
 const PieChartCard = ({
   pieChartData,
   dynamicColors,
@@ -152,6 +207,7 @@ export default function InsightsCourse({
   pieChartDataLoading,
   pieChartError,
   barChartError,
+  courseStatusData,
 }: InsightsCourseProps) {
   const dynamicColors = generateDynamicColors(
     Math.max(barChartData.length, pieChartData.length)
@@ -186,6 +242,13 @@ export default function InsightsCourse({
           />
         )}
       </div>
+
+      {/* Course Status Pie Chart */}
+      {courseStatusData && courseStatusData.length > 0 && (
+        <div className="mb-4">
+          <CourseStatusPieChart data={courseStatusData} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/dashboard/@lms_admin/insights/courses/page.tsx
+++ b/src/app/dashboard/@lms_admin/insights/courses/page.tsx
@@ -1,7 +1,7 @@
 import dynamic from 'next/dynamic';
 import InsightsCourse from './InsightsCourse';
 import NavLMS from '@/hoc/nav-lms.hoc';
-import { fetchCoursesByCategory, fetchCoursesPerMonth} from '@/action/lms-admin/insights/courses/coursesAction';
+import { fetchCoursesByCategory, fetchCoursesPerMonth, fetchCourseStatusCounts } from '@/action/lms-admin/insights/courses/coursesAction';
 import TableSkeleton from '@/components/skeleton/TableSkeleton';
 // import CoursesDataInsightsTablePage from './@table/page';
 const CoursesDataInsightsTablePage = dynamic(() => import('./@table/page'), {
@@ -12,8 +12,15 @@ const CoursesDataInsightsTablePage = dynamic(() => import('./@table/page'), {
 
 export default async function InsightPage({ searchParams }: { searchParams: { page?: string , course?: string , department?: string } }) {
   // Fetch data for charts
-  const { loading: pieChartLoading, data: pieChartData, errorMessage: pieChartError } = await fetchCoursesByCategory();
-  const { loading: barChartLoading, data: barChartData, errorMessage: barChartError } = await fetchCoursesPerMonth();
+  const [
+    { loading: pieChartLoading, data: pieChartData, errorMessage: pieChartError },
+    { loading: barChartLoading, data: barChartData, errorMessage: barChartError },
+    courseStatusData,
+  ] = await Promise.all([
+    fetchCoursesByCategory(),
+    fetchCoursesPerMonth(),
+    fetchCourseStatusCounts(),
+  ]);
 
   return (
     <div className="flex flex-col">
@@ -25,6 +32,7 @@ export default async function InsightPage({ searchParams }: { searchParams: { pa
           pieChartDataLoading={pieChartLoading}
           pieChartError={pieChartError}
           barChartError={barChartError}
+          courseStatusData={courseStatusData}
         />
         <CoursesDataInsightsTablePage searchParams={searchParams} />
       </NavLMS>

--- a/src/app/dashboard/@lms_admin/insights/courses/type.ts
+++ b/src/app/dashboard/@lms_admin/insights/courses/type.ts
@@ -39,5 +39,6 @@ export interface InsightsCourseProps {
   pieChartDataLoading: boolean
   barChartError: string
   pieChartError: string
+  courseStatusData?: CategoryData[];
 }
 

--- a/src/app/dashboard/@lms_admin/insights/quiz-results/page.tsx
+++ b/src/app/dashboard/@lms_admin/insights/quiz-results/page.tsx
@@ -1,0 +1,27 @@
+import NavLMS from '@/hoc/nav-lms.hoc'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ClipboardCheck } from 'lucide-react'
+
+export default function QuizResultsPage() {
+  return (
+    <div className="flex flex-col">
+      <NavLMS data={[]}>
+        <Card className="mx-auto max-w-lg mt-12">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+              <ClipboardCheck className="h-6 w-6 text-primary" />
+            </div>
+            <CardTitle>Quiz Results</CardTitle>
+          </CardHeader>
+          <CardContent className="text-center">
+            <p className="text-muted-foreground">
+              Quiz analytics and detailed result breakdowns are coming soon.
+              You will be able to view pass/fail rates, score distributions,
+              and per-question analysis here.
+            </p>
+          </CardContent>
+        </Card>
+      </NavLMS>
+    </div>
+  )
+}

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -42,9 +42,10 @@ interface DataTableProps<TData> {
   headerLinks?: () => React.ReactNode
   controls?: () => React.ReactNode
   pagination?: boolean;
+  renderMobileCard?: (row: TData) => React.ReactNode;
 }
 
-export function DataTableComponent<TData>({ columns, data, renderToolbar, actionTable, headerLinks, controls, pagination = false }: DataTableProps<TData>) {
+export function DataTableComponent<TData>({ columns, data, renderToolbar, actionTable, headerLinks, controls, pagination = false, renderMobileCard }: DataTableProps<TData>) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const { isRTL } = useLanguage()
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
@@ -83,7 +84,24 @@ export function DataTableComponent<TData>({ columns, data, renderToolbar, action
           {headerLinks && headerLinks()}
         </div>
       </div>
-      <div className="rounded-md border grid ">
+
+      {/* Mobile card layout */}
+      {renderMobileCard && (
+        <div className="md:hidden space-y-3">
+          {data.length > 0 ? (
+            table.getRowModel().rows.map((row) => (
+              <React.Fragment key={row.id}>
+                {renderMobileCard(row.original)}
+              </React.Fragment>
+            ))
+          ) : (
+            <p className="text-center text-muted-foreground py-8">No data available</p>
+          )}
+        </div>
+      )}
+
+      {/* Desktop table layout */}
+      <div className={`rounded-md border grid ${renderMobileCard ? 'hidden md:grid' : ''}`}>
         <ScrollArea className="h-[80vh]" dir={isRTL ? 'rtl' : "ltr"}>
           <Table>
             <TableHeader className='bg-primary sticky top-0 z-[3]'>

--- a/src/hoc/nav-lms.hoc.tsx
+++ b/src/hoc/nav-lms.hoc.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/components/ui/button'
 import {
   Book,
   BookOpen,
+  ClipboardCheck,
   FileIcon,
 
   Home,
@@ -56,6 +57,7 @@ const navigationItems = [
   { name: 'Enrollments', href: '/dashboard/insights/enrollments', icon: Book },
   { name: 'Completions', href: '/dashboard/insights/completions', icon: FileIcon },
   { name: 'Courses', href: '/dashboard/insights/courses', icon: BookOpen },
+  { name: 'Quiz Results', href: '/dashboard/insights/quiz-results', icon: ClipboardCheck },
 ]
 
 export default function NavLMS<T extends Data>({ children, data }: NavLMSProps<T>) {


### PR DESCRIPTION
…t, mobile cards

1. CardStatus: add colored TrendingUp/TrendingDown/Minus icons next to month-over-month change, responsive font sizes (text-lg → text-2xl)
2. NavLMS: add "Quiz Results" tab with ClipboardCheck icon, linking to new /dashboard/insights/quiz-results placeholder page
3. InsightsCourse: add "Course Status Distribution" pie chart showing Published/Draft/Archived counts with fixed green/amber/gray colors
4. DataTable: add optional renderMobileCard prop — when provided, shows stacked card layout on mobile (md:hidden) and hides the scroll table
5. CourseTable + CompletionsDataTable: implement renderMobileCard with thumbnail, key metrics, progress bar, and action button

https://claude.ai/code/session_01SC1b8MQuxedfJebyopteX2