### PR TITLE
Close Phase 2 AI gaps: encrypt API keys, use org config, enforce rate…

### DIFF
--- a/src/app/api/ai-config/route.ts
+++ b/src/app/api/ai-config/route.ts
@@ -1,0 +1,97 @@
+import { createClient } from '@/utils/supabase/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { encryptApiKey } from '@/lib/ai/encryption';
+
+// POST: Save org AI configuration (server-side, encrypts API key)
+export async function POST(req: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Verify admin role
+    const { data: userData } = await supabase
+      .from('users')
+      .select('role')
+      .eq('id', user.id)
+      .single();
+
+    if (!userData || !['organizationAdmin', 'LMSAdmin', 'superAdmin'].includes(userData.role)) {
+      return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 });
+    }
+
+    const body = await req.json();
+    const {
+      provider,
+      model,
+      apiKey,
+      systemPrompt,
+      temperature,
+      maxTokens,
+      rateLimitRpm,
+      rateLimitRpd,
+      chatEnabled,
+      searchEnabled,
+      recommendationsEnabled,
+    } = body;
+
+    // Encrypt the API key if provided (otherwise pass null to keep existing)
+    let encryptedKey: string | null = null;
+    if (apiKey && typeof apiKey === 'string' && apiKey.trim().length > 0) {
+      encryptedKey = encryptApiKey(apiKey.trim());
+    }
+
+    const { error } = await supabase.rpc('upsert_org_ai_config', {
+      p_provider: provider || 'anthropic',
+      p_model: model || 'claude-sonnet-4-5-20250929',
+      p_api_key: encryptedKey,
+      p_system_prompt: systemPrompt || null,
+      p_temperature: temperature ?? 0.7,
+      p_max_tokens: maxTokens ?? 2048,
+      p_rate_limit_rpm: rateLimitRpm ?? 30,
+      p_rate_limit_rpd: rateLimitRpd ?? 500,
+      p_chat_enabled: chatEnabled ?? true,
+      p_search_enabled: searchEnabled ?? true,
+      p_recommendations_enabled: recommendationsEnabled ?? true,
+    });
+
+    if (error) {
+      console.error('Failed to save AI config:', error);
+      return NextResponse.json({ error: 'Failed to save configuration' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('AI config API error:', error);
+    return NextResponse.json(
+      { error: 'Failed to save configuration' },
+      { status: 500 }
+    );
+  }
+}
+
+// GET: Retrieve org AI configuration (without decrypted key)
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { data } = await supabase.rpc('get_org_ai_config');
+    const config = Array.isArray(data) ? data[0] : data;
+
+    return NextResponse.json({ config: config || null });
+  } catch (error) {
+    console.error('AI config GET error:', error);
+    return NextResponse.json(
+      { error: 'Failed to load configuration' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,8 +1,7 @@
 import { createClient } from '@/utils/supabase/server';
 import { NextRequest } from 'next/server';
-import { streamText, createUIMessageStreamResponse } from 'ai';
-import { createAnthropic } from '@ai-sdk/anthropic';
-import { createOpenAI } from '@ai-sdk/openai';
+import { streamText } from 'ai';
+import { getAIProvider, logUsage, GatewayError } from '@/lib/ai/gateway';
 
 export const maxDuration = 60;
 
@@ -21,11 +20,23 @@ export async function POST(req: NextRequest) {
       return new Response('Message is required', { status: 400 });
     }
 
-    // Get org AI config
-    const { data: configs } = await supabase.rpc('get_org_ai_config');
-    const config = Array.isArray(configs) ? configs[0] : configs;
+    // Get AI provider via gateway (reads org config, decrypts key, checks rate limits)
+    let gateway;
+    try {
+      gateway = await getAIProvider(supabase, user.id, 'chat');
+    } catch (err) {
+      if (err instanceof GatewayError) {
+        return new Response(
+          JSON.stringify({ error: err.message }),
+          { status: err.status, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      throw err;
+    }
 
-    if (!config?.chat_enabled) {
+    const { config, model } = gateway;
+
+    if (!config.chat_enabled) {
       return new Response('AI Chat is not enabled for this organization', { status: 403 });
     }
 
@@ -89,23 +100,7 @@ ${ragContext || 'No course data available yet.'}
 - Respond in the same language as the user's question (Arabic or English)
 - Keep responses concise and actionable`;
 
-    // Create provider based on config
-    const provider = config.provider || 'anthropic';
     const modelName = config.model || 'claude-sonnet-4-5-20250929';
-
-    let model;
-    if (provider === 'openai') {
-      const openai = createOpenAI({
-        apiKey: process.env.OPENAI_API_KEY || '',
-      });
-      model = openai(modelName);
-    } else {
-      // Default to Anthropic
-      const anthropic = createAnthropic({
-        apiKey: process.env.ANTHROPIC_API_KEY || '',
-      });
-      model = anthropic(modelName);
-    }
 
     // Stream the response
     const result = streamText({
@@ -126,6 +121,9 @@ ${ragContext || 'No course data available yet.'}
             p_model: modelName,
           });
         }
+
+        // Log usage
+        await logUsage(supabase, 'chat');
       },
     });
 

--- a/src/app/api/embeddings/route.ts
+++ b/src/app/api/embeddings/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@/utils/supabase/server';
 import { NextRequest, NextResponse } from 'next/server';
+import { getOrgConfig, resolveEmbeddingApiKey, logUsage } from '@/lib/ai/gateway';
 
 // POST: Generate embeddings for courses in the organization.
 // Called by admin to index/re-index course content for semantic search.
@@ -24,11 +25,14 @@ export async function POST(req: NextRequest) {
     }
 
     const orgId = userData.organization_id;
-    const embeddingApiKey = process.env.OPENAI_API_KEY;
+
+    // Resolve embedding API key from org config (with env var fallback)
+    const config = await getOrgConfig(supabase);
+    const embeddingApiKey = resolveEmbeddingApiKey(config);
 
     if (!embeddingApiKey) {
       return NextResponse.json(
-        { error: 'Embedding API key not configured' },
+        { error: 'Embedding API key not configured. Set an OpenAI API key in org settings or OPENAI_API_KEY env var.' },
         { status: 500 }
       );
     }
@@ -124,6 +128,9 @@ export async function POST(req: NextRequest) {
         }
       }
     }
+
+    // Log usage
+    await logUsage(supabase, 'embeddings');
 
     return NextResponse.json({
       message: `Embedded ${embeddedCount} chunks from ${courses.length} courses`,

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@/utils/supabase/server';
 import { NextRequest, NextResponse } from 'next/server';
+import { getOrgConfig, checkRateLimit, logUsage, resolveEmbeddingApiKey } from '@/lib/ai/gateway';
 
 export async function POST(req: NextRequest) {
   try {
@@ -29,9 +30,17 @@ export async function POST(req: NextRequest) {
 
     const orgId = userData.organization_id;
 
-    // Check if AI search is enabled
-    const { data: configs } = await supabase.rpc('get_org_ai_config');
-    const config = Array.isArray(configs) ? configs[0] : configs;
+    // Get org AI config via gateway
+    const config = await getOrgConfig(supabase);
+
+    // Check rate limits for search
+    const rateLimit = await checkRateLimit(supabase, user.id, 'search');
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: 'Rate limit exceeded. Please try again later.' },
+        { status: 429 }
+      );
+    }
 
     // Strategy 1: Text-based search (always available, fast)
     const { data: textResults } = await supabase
@@ -62,8 +71,9 @@ export async function POST(req: NextRequest) {
     }> = [];
 
     if (config?.search_enabled) {
-      // Generate embedding for the query using OpenAI API
-      const embeddingApiKey = process.env.OPENAI_API_KEY;
+      // Resolve embedding API key from org config (with env var fallback)
+      const embeddingApiKey = resolveEmbeddingApiKey(config);
+
       if (embeddingApiKey) {
         try {
           const embeddingResponse = await fetch('https://api.openai.com/v1/embeddings', {
@@ -100,6 +110,9 @@ export async function POST(req: NextRequest) {
         }
       }
     }
+
+    // Log usage
+    await logUsage(supabase, 'search');
 
     // Merge and deduplicate results (semantic first, then text)
     const seenIds = new Set<number>();

--- a/src/components/ai/AIConfigForm.tsx
+++ b/src/components/ai/AIConfigForm.tsx
@@ -78,21 +78,30 @@ export function AIConfigForm({ lang = "en" }: AIConfigFormProps) {
     setSaveStatus("idle");
 
     try {
-      const { error } = await supabase.rpc("upsert_org_ai_config", {
-        p_provider: provider,
-        p_model: model,
-        p_api_key: apiKey || null,
-        p_system_prompt: systemPrompt,
-        p_temperature: temperature,
-        p_max_tokens: maxTokens,
-        p_rate_limit_rpm: rateLimitRpm,
-        p_rate_limit_rpd: rateLimitRpd,
-        p_chat_enabled: chatEnabled,
-        p_search_enabled: searchEnabled,
-        p_recommendations_enabled: recommendationsEnabled,
+      // POST to server-side API route — encrypts API key before storing
+      const res = await fetch("/api/ai-config", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider,
+          model,
+          apiKey: apiKey || null,
+          systemPrompt,
+          temperature,
+          maxTokens,
+          rateLimitRpm,
+          rateLimitRpd,
+          chatEnabled,
+          searchEnabled,
+          recommendationsEnabled,
+        }),
       });
 
-      if (error) throw error;
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to save");
+      }
+
       setSaveStatus("success");
       setApiKey(""); // Clear API key field after save
       setTimeout(() => setSaveStatus("idle"), 3000);

--- a/src/lib/ai/encryption.ts
+++ b/src/lib/ai/encryption.ts
@@ -1,0 +1,79 @@
+// ============================================================================
+// AI API Key Encryption — AES-256-GCM
+// ============================================================================
+// Encrypts org API keys before storing in database.
+// Requires AI_ENCRYPTION_KEY env var (32-byte hex string = 64 hex characters).
+//
+// Format: base64(iv:authTag:ciphertext)
+// ============================================================================
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+
+function getEncryptionKey(): Buffer {
+  const key = process.env.AI_ENCRYPTION_KEY;
+  if (!key) {
+    throw new Error(
+      'AI_ENCRYPTION_KEY environment variable is required. ' +
+      'Generate one with: openssl rand -hex 32'
+    );
+  }
+  const buf = Buffer.from(key, 'hex');
+  if (buf.length !== 32) {
+    throw new Error(
+      'AI_ENCRYPTION_KEY must be a 64-character hex string (32 bytes). ' +
+      'Generate one with: openssl rand -hex 32'
+    );
+  }
+  return buf;
+}
+
+/**
+ * Encrypt a plaintext API key for storage.
+ * Returns a base64 string containing iv + authTag + ciphertext.
+ */
+export function encryptApiKey(plaintext: string): string {
+  const key = getEncryptionKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  // Pack: iv (16) + authTag (16) + ciphertext (variable)
+  const packed = Buffer.concat([iv, authTag, encrypted]);
+  return packed.toString('base64');
+}
+
+/**
+ * Decrypt a stored API key.
+ * Expects the base64 format produced by encryptApiKey().
+ */
+export function decryptApiKey(encryptedBase64: string): string {
+  const key = getEncryptionKey();
+  const packed = Buffer.from(encryptedBase64, 'base64');
+
+  if (packed.length < IV_LENGTH + AUTH_TAG_LENGTH + 1) {
+    throw new Error('Invalid encrypted API key format');
+  }
+
+  const iv = packed.subarray(0, IV_LENGTH);
+  const authTag = packed.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+  const ciphertext = packed.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  const decrypted = Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]);
+
+  return decrypted.toString('utf8');
+}

--- a/src/lib/ai/gateway.ts
+++ b/src/lib/ai/gateway.ts
@@ -1,0 +1,214 @@
+// ============================================================================
+// AI Gateway — Central provider factory with rate limiting
+// ============================================================================
+// All AI API routes go through this gateway to:
+// 1. Read the org's AI config (with encrypted API key)
+// 2. Decrypt the org's API key (or fall back to env vars)
+// 3. Check rate limits before allowing the request
+// 4. Return the correct AI SDK provider/model instance
+// ============================================================================
+
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
+import { decryptApiKey } from './encryption';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface OrgAIConfigWithKey {
+  id: number;
+  organization_id: number;
+  provider: string;
+  model: string;
+  api_key_encrypted: string | null;
+  system_prompt: string;
+  temperature: number;
+  max_tokens: number;
+  rate_limit_rpm: number;
+  rate_limit_rpd: number;
+  chat_enabled: boolean;
+  search_enabled: boolean;
+  recommendations_enabled: boolean;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  requests_minute: number;
+  limit_minute: number;
+  requests_day: number;
+  limit_day: number;
+}
+
+export interface GatewayResult {
+  config: OrgAIConfigWithKey;
+  model: ReturnType<ReturnType<typeof createAnthropic>> | ReturnType<ReturnType<typeof createOpenAI>>;
+  apiKey: string;
+}
+
+/**
+ * Resolve the API key for a given provider.
+ * Priority: org-specific encrypted key > environment variable.
+ */
+function resolveApiKey(provider: string, encryptedKey: string | null): string {
+  // Try org-specific key first
+  if (encryptedKey) {
+    try {
+      return decryptApiKey(encryptedKey);
+    } catch (err) {
+      console.warn('Failed to decrypt org API key, falling back to env var:', err);
+    }
+  }
+
+  // Fall back to environment variables
+  switch (provider) {
+    case 'anthropic':
+      return process.env.ANTHROPIC_API_KEY || '';
+    case 'openai':
+      return process.env.OPENAI_API_KEY || '';
+    case 'google':
+      return process.env.GOOGLE_AI_API_KEY || '';
+    default:
+      return process.env.OPENAI_API_KEY || '';
+  }
+}
+
+/**
+ * Resolve the API key specifically for embedding operations.
+ * Embeddings always use OpenAI (text-embedding-3-small), so we check for
+ * an org key first, then fall back to OPENAI_API_KEY env var.
+ */
+export function resolveEmbeddingApiKey(config: OrgAIConfigWithKey | null): string {
+  // If org has an OpenAI key stored (or their provider is openai), try decrypting it
+  if (config?.api_key_encrypted && config.provider === 'openai') {
+    try {
+      return decryptApiKey(config.api_key_encrypted);
+    } catch {
+      // fall through
+    }
+  }
+
+  // Fall back to env var (embeddings always use OpenAI)
+  return process.env.OPENAI_API_KEY || '';
+}
+
+/**
+ * Get the org AI config including the encrypted API key.
+ */
+export async function getOrgConfig(
+  supabase: SupabaseClient
+): Promise<OrgAIConfigWithKey | null> {
+  const { data } = await supabase.rpc('get_org_ai_config_with_key');
+  const config = Array.isArray(data) ? data[0] : data;
+  return config || null;
+}
+
+/**
+ * Check rate limits for the current user/org/endpoint.
+ * Returns the rate limit status.
+ */
+export async function checkRateLimit(
+  supabase: SupabaseClient,
+  userId: string,
+  endpoint: string
+): Promise<RateLimitResult> {
+  const { data } = await supabase.rpc('check_ai_rate_limit', {
+    p_user_id: userId,
+    p_endpoint: endpoint,
+  });
+
+  const result = Array.isArray(data) ? data[0] : data;
+
+  if (!result) {
+    // If RPC fails (e.g., no config), allow by default
+    return {
+      allowed: true,
+      requests_minute: 0,
+      limit_minute: 30,
+      requests_day: 0,
+      limit_day: 500,
+    };
+  }
+
+  return result as RateLimitResult;
+}
+
+/**
+ * Log a usage event after a successful AI API call.
+ */
+export async function logUsage(
+  supabase: SupabaseClient,
+  endpoint: string,
+  tokensUsed: number = 0
+): Promise<void> {
+  await supabase.rpc('log_ai_usage', {
+    p_endpoint: endpoint,
+    p_tokens_used: tokensUsed,
+  });
+}
+
+/**
+ * Main gateway entry point.
+ * Reads org config, checks rate limits, returns the AI model instance.
+ *
+ * Throws an error with status info if rate limited or misconfigured.
+ */
+export async function getAIProvider(
+  supabase: SupabaseClient,
+  userId: string,
+  endpoint: string
+): Promise<GatewayResult> {
+  // 1. Get org config
+  const config = await getOrgConfig(supabase);
+
+  if (!config) {
+    throw new GatewayError('AI is not configured for this organization', 403);
+  }
+
+  // 2. Check rate limits
+  const rateLimit = await checkRateLimit(supabase, userId, endpoint);
+
+  if (!rateLimit.allowed) {
+    const isMinuteLimit = rateLimit.requests_minute >= rateLimit.limit_minute;
+    const detail = isMinuteLimit
+      ? `Rate limit exceeded: ${rateLimit.requests_minute}/${rateLimit.limit_minute} requests per minute`
+      : `Daily limit exceeded: ${rateLimit.requests_day}/${rateLimit.limit_day} requests per day`;
+
+    throw new GatewayError(detail, 429);
+  }
+
+  // 3. Resolve API key
+  const provider = config.provider || 'anthropic';
+  const modelName = config.model || 'claude-sonnet-4-5-20250929';
+  const apiKey = resolveApiKey(provider, config.api_key_encrypted);
+
+  if (!apiKey) {
+    throw new GatewayError(
+      'No API key configured. Set an org-level key or add the provider environment variable.',
+      500
+    );
+  }
+
+  // 4. Create provider instance
+  let model;
+  if (provider === 'openai') {
+    const openai = createOpenAI({ apiKey });
+    model = openai(modelName);
+  } else {
+    // Default to Anthropic for anthropic, google, jais, custom
+    const anthropic = createAnthropic({ apiKey });
+    model = anthropic(modelName);
+  }
+
+  return { config, model, apiKey };
+}
+
+/**
+ * Custom error class with HTTP status code.
+ */
+export class GatewayError extends Error {
+  constructor(
+    message: string,
+    public status: number
+  ) {
+    super(message);
+    this.name = 'GatewayError';
+  }
+}

--- a/supabase/migrations/20260222120000_ai_gap_fixes.sql
+++ b/supabase/migrations/20260222120000_ai_gap_fixes.sql
@@ -1,0 +1,163 @@
+-- ============================================================================
+-- Jadarat LMS – Phase 2 Gap Fixes
+-- ============================================================================
+-- 1. get_org_ai_config_with_key — returns encrypted API key (server-side only)
+-- 2. ai_usage_log — tracks per-request usage for rate limiting
+-- 3. check_ai_rate_limit — enforces rpm/rpd limits
+-- 4. log_ai_usage — records a usage event
+-- ============================================================================
+
+
+-- ==========  1. RPC: get_org_ai_config_with_key  ==========
+-- Same as get_org_ai_config but INCLUDES the encrypted API key.
+-- Used server-side by API routes (never exposed to client).
+
+CREATE OR REPLACE FUNCTION public.get_org_ai_config_with_key()
+RETURNS TABLE (
+  id                      INT,
+  organization_id         INT,
+  provider                TEXT,
+  model                   TEXT,
+  api_key_encrypted       TEXT,
+  system_prompt           TEXT,
+  temperature             NUMERIC,
+  max_tokens              INT,
+  rate_limit_rpm          INT,
+  rate_limit_rpd          INT,
+  chat_enabled            BOOLEAN,
+  search_enabled          BOOLEAN,
+  recommendations_enabled BOOLEAN,
+  created_at              TIMESTAMPTZ,
+  updated_at              TIMESTAMPTZ
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT c.id, c.organization_id, c.provider::text, c.model,
+         c.api_key_encrypted,
+         c.system_prompt, c.temperature, c.max_tokens,
+         c.rate_limit_rpm, c.rate_limit_rpd,
+         c.chat_enabled, c.search_enabled, c.recommendations_enabled,
+         c.created_at, c.updated_at
+  FROM org_ai_config c
+  WHERE c.organization_id = (SELECT organization_id FROM users WHERE id = auth.uid());
+$$;
+
+
+-- ==========  2. TABLE: ai_usage_log  ==========
+-- One row per AI API call, used for rate limiting and usage tracking.
+
+CREATE TABLE public.ai_usage_log (
+  id                SERIAL        PRIMARY KEY,
+  organization_id   INT           NOT NULL REFERENCES public.organization(id) ON DELETE CASCADE,
+  user_id           UUID          NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  endpoint          TEXT          NOT NULL,  -- 'chat', 'search', 'embeddings'
+  tokens_used       INT           DEFAULT 0,
+  created_at        TIMESTAMPTZ   NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_ai_usage_log_org_time ON public.ai_usage_log (organization_id, created_at DESC);
+CREATE INDEX idx_ai_usage_log_user_time ON public.ai_usage_log (user_id, created_at DESC);
+
+ALTER TABLE public.ai_usage_log ENABLE ROW LEVEL SECURITY;
+
+-- Only admins can view usage logs for their org
+CREATE POLICY "Admins can view org usage logs"
+  ON public.ai_usage_log FOR SELECT
+  USING (
+    organization_id = (SELECT organization_id FROM users WHERE id = auth.uid())
+    AND (SELECT role FROM users WHERE id = auth.uid()) IN ('organizationAdmin', 'LMSAdmin', 'superAdmin')
+  );
+
+-- Any authenticated user can insert (server-side via SECURITY DEFINER functions)
+CREATE POLICY "System can insert usage logs"
+  ON public.ai_usage_log FOR INSERT
+  WITH CHECK (true);
+
+
+-- ==========  3. RPC: check_ai_rate_limit  ==========
+-- Returns whether the user is within their org's rate limits.
+-- Checks both per-minute (rpm) and per-day (rpd) limits.
+
+CREATE OR REPLACE FUNCTION public.check_ai_rate_limit(
+  p_user_id   UUID,
+  p_endpoint  TEXT DEFAULT 'chat'
+)
+RETURNS TABLE (
+  allowed           BOOLEAN,
+  requests_minute   BIGINT,
+  limit_minute      INT,
+  requests_day      BIGINT,
+  limit_day         INT
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  _org_id       INT;
+  _rpm_limit    INT;
+  _rpd_limit    INT;
+  _rpm_count    BIGINT;
+  _rpd_count    BIGINT;
+BEGIN
+  -- Get org and limits
+  SELECT u.organization_id INTO _org_id FROM users u WHERE u.id = p_user_id;
+
+  SELECT c.rate_limit_rpm, c.rate_limit_rpd
+    INTO _rpm_limit, _rpd_limit
+    FROM org_ai_config c
+    WHERE c.organization_id = _org_id;
+
+  -- Default limits if no config exists
+  _rpm_limit := COALESCE(_rpm_limit, 30);
+  _rpd_limit := COALESCE(_rpd_limit, 500);
+
+  -- Count requests in the last minute (per user)
+  SELECT count(*) INTO _rpm_count
+    FROM ai_usage_log l
+    WHERE l.user_id = p_user_id
+      AND l.endpoint = p_endpoint
+      AND l.created_at > now() - interval '1 minute';
+
+  -- Count requests in the last 24 hours (per org)
+  SELECT count(*) INTO _rpd_count
+    FROM ai_usage_log l
+    WHERE l.organization_id = _org_id
+      AND l.endpoint = p_endpoint
+      AND l.created_at > now() - interval '1 day';
+
+  RETURN QUERY SELECT
+    (_rpm_count < _rpm_limit AND _rpd_count < _rpd_limit) AS allowed,
+    _rpm_count  AS requests_minute,
+    _rpm_limit  AS limit_minute,
+    _rpd_count  AS requests_day,
+    _rpd_limit  AS limit_day;
+END;
+$$;
+
+
+-- ==========  4. RPC: log_ai_usage  ==========
+-- Records a single usage event. Called after successful AI API calls.
+
+CREATE OR REPLACE FUNCTION public.log_ai_usage(
+  p_endpoint    TEXT,
+  p_tokens_used INT DEFAULT 0
+)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  _org_id INT;
+BEGIN
+  SELECT organization_id INTO _org_id FROM users WHERE id = auth.uid();
+
+  INSERT INTO ai_usage_log (organization_id, user_id, endpoint, tokens_used)
+  VALUES (_org_id, auth.uid(), p_endpoint, p_tokens_used);
+END;
+$$;
+
+
+-- ==========  5. Cleanup: purge old usage logs  ==========
+-- Optional: auto-purge logs older than 90 days (run via cron or pg_cron).
+-- CREATE OR REPLACE FUNCTION public.purge_old_ai_usage_logs()
+-- RETURNS void LANGUAGE sql AS $$
+--   DELETE FROM ai_usage_log WHERE created_at < now() - interval '90 days';
+-- $$;


### PR DESCRIPTION
… limits

- Add AES-256-GCM encryption for org API keys (src/lib/ai/encryption.ts)
- Create central AI Gateway that reads org config, decrypts keys, and checks rate limits before returning provider instances (src/lib/ai/gateway.ts)
- Add server-side /api/ai-config route so API keys are encrypted before storage (never sent plaintext from client to DB)
- Refactor /api/chat, /api/search, /api/embeddings to use gateway instead of hardcoded process.env.* — org keys used with env var fallback
- Add ai_usage_log table, check_ai_rate_limit and log_ai_usage RPCs to enforce per-user rpm and per-org rpd limits
- Update AIConfigForm to POST to /api/ai-config instead of calling upsert RPC directly from the browser

https://claude.ai/code/session_01SC1b8MQuxedfJebyopteX2