### PR TITLE
Replace hardcoded colors with semantic design tokens across 21 remain…

### DIFF
--- a/src/app/create-account/CreateAccount.tsx
+++ b/src/app/create-account/CreateAccount.tsx
@@ -154,7 +154,7 @@ export default function CreateAccount() {
         <Dialog>
           <DialogContent>
             <div className="flex flex-col items-center justify-center gap-4 py-8">
-              <CircleCheckIcon className="size-12 text-green-500" />
+              <CircleCheckIcon className="size-12 text-success" />
               <p className="text-lg font-medium">Please check your email for confirmation.</p>
             </div>
             <DialogFooter>

--- a/src/app/dashboard/@learner/course/[id]/CourseNotFound.tsx
+++ b/src/app/dashboard/@learner/course/[id]/CourseNotFound.tsx
@@ -13,7 +13,7 @@ export default function CourseNotFound() {
    <Card className="w-full max-w-md">
     <CardHeader className="text-center">
      <div className="flex justify-center mb-4">
-      <XCircle className="h-12 w-12 text-red-500" />
+      <XCircle className="h-12 w-12 text-destructive" />
      </div>
      <CardTitle className="text-2xl font-bold">Course Unavailable</CardTitle>
     </CardHeader>

--- a/src/app/dashboard/@lms_admin/(courses_categorise)/courses/add-course/CourseForm.tsx
+++ b/src/app/dashboard/@lms_admin/(courses_categorise)/courses/add-course/CourseForm.tsx
@@ -174,7 +174,7 @@ export function CourseForm({ onSave, onChange, isLoading, initialData = {}, cate
                 />
               )}
             />
-            {errors.title && <p className="text-sm text-red-500 mt-1">{errors.title.message}</p>}
+            {errors.title && <p className="text-sm text-destructive mt-1">{errors.title.message}</p>}
           </div>
 
           <div>
@@ -195,7 +195,7 @@ export function CourseForm({ onSave, onChange, isLoading, initialData = {}, cate
                 />
               )}
             />
-            {errors.description && <p className="text-sm text-red-500 mt-1">{errors.description.message}</p>}
+            {errors.description && <p className="text-sm text-destructive mt-1">{errors.description.message}</p>}
           </div>
 
           <div>
@@ -222,7 +222,7 @@ export function CourseForm({ onSave, onChange, isLoading, initialData = {}, cate
                 </Select>
               )}
             />
-            {errors.level && <p className="text-sm text-red-500 mt-1">{errors.level.message}</p>}
+            {errors.level && <p className="text-sm text-destructive mt-1">{errors.level.message}</p>}
           </div>
 
           <div>
@@ -261,7 +261,7 @@ export function CourseForm({ onSave, onChange, isLoading, initialData = {}, cate
                 </Select>
               )}
             />
-            {errors.category_id && <p className="text-sm text-red-500 mt-1">{errors.category_id.message}</p>}
+            {errors.category_id && <p className="text-sm text-destructive mt-1">{errors.category_id.message}</p>}
           </div>
 
           <CourseOutcome
@@ -294,10 +294,10 @@ export function CourseForm({ onSave, onChange, isLoading, initialData = {}, cate
                 />
               )}
             />
-            <p className="text-sm text-gray-500 mt-1">
+            <p className="text-sm text-muted-foreground mt-1">
               A valid slug should only contain lowercase letters, numbers, and hyphens (e.g., <code>course-title</code>).
             </p>
-            {errors.slug && <p className="text-sm text-red-500 mt-1">{errors.slug.message}</p>}
+            {errors.slug && <p className="text-sm text-destructive mt-1">{errors.slug.message}</p>}
           </div>
 
           <div>
@@ -319,7 +319,7 @@ export function CourseForm({ onSave, onChange, isLoading, initialData = {}, cate
                 />
               )}
             />
-            {errors.timeline && <p className="text-sm text-red-500 mt-1">{errors.timeline.message}</p>}
+            {errors.timeline && <p className="text-sm text-destructive mt-1">{errors.timeline.message}</p>}
           </div>
 
           {isScormFlow && (
@@ -355,13 +355,13 @@ export function CourseForm({ onSave, onChange, isLoading, initialData = {}, cate
                   )}
                 />
                 {errors.scormVersion && (
-                  <p className="text-sm text-red-500 mt-1">{errors.scormVersion.message}</p>
+                  <p className="text-sm text-destructive mt-1">{errors.scormVersion.message}</p>
                 )}
               </div>
               {selectedScormVersion ? (
                 <ZipUploader onFileUpdate={handleScormUpload} />
               ) : (
-                <div className="text-sm text-amber-600">
+                <div className="text-sm text-amber-600 dark:text-amber-400">
                   Please select a SCORM version before uploading a file
                 </div>
               )}

--- a/src/app/dashboard/@lms_admin/enrollments/ActionEnrollmentTable.tsx
+++ b/src/app/dashboard/@lms_admin/enrollments/ActionEnrollmentTable.tsx
@@ -152,7 +152,7 @@ function ActionEnrollmentTable() {
                                 onChange={(e) => setLearnerSearch(e.target.value)}
                             />
                             {learnersLoading && <p>Loading learners...</p>}
-                            {learnersError && <p className="text-red-500">{learnersError}</p>}
+                            {learnersError && <p className="text-sm text-destructive">{learnersError}</p>}
                             <div className="flex flex-wrap gap-2 mt-2">
                                 {selectedLearners.map(learner => (
                                     <Badge key={learner.id} variant="secondary">
@@ -168,7 +168,7 @@ function ActionEnrollmentTable() {
                                     {filteredLearners.map(learner => (
                                         <li
                                             key={learner.id}
-                                            className="cursor-pointer hover:bg-accent p-1"
+                                            className="cursor-pointer hover:bg-accent p-1 rounded-md transition-colors"
                                             onClick={() => handleSelectLearner(learner)}
                                         >
                                             {learner.name}
@@ -186,7 +186,7 @@ function ActionEnrollmentTable() {
                                 onChange={(e) => setCourseSearch(e.target.value)}
                             />
                             {coursesLoading && <p>Loading courses...</p>}
-                            {coursesError && <p className="text-red-500">{coursesError}</p>}
+                            {coursesError && <p className="text-sm text-destructive">{coursesError}</p>}
                             <div className="flex flex-wrap gap-2 mt-2">
                                 {selectedCourses.map(course => (
                                     <Badge key={course.course_id} variant="secondary">
@@ -202,7 +202,7 @@ function ActionEnrollmentTable() {
                                     {filteredCourses.map(course => (
                                         <li
                                             key={course.course_id}
-                                            className="cursor-pointer hover:bg-accent p-1"
+                                            className="cursor-pointer hover:bg-accent p-1 rounded-md transition-colors"
                                             onClick={() => handleSelectCourse(course)}
                                         >
                                             {course.title}

--- a/src/app/dashboard/@lms_admin/gamification-config/GamificationConfigPage.tsx
+++ b/src/app/dashboard/@lms_admin/gamification-config/GamificationConfigPage.tsx
@@ -207,7 +207,7 @@ export default function GamificationConfigPage() {
 
       {/* Summary Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <Card>
+        <Card className="hover:shadow-md transition-shadow duration-200">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">Total Levels</CardTitle>
           </CardHeader>
@@ -215,21 +215,21 @@ export default function GamificationConfigPage() {
             <div className="text-2xl font-bold">{totalEnabledLevels}</div>
           </CardContent>
         </Card>
-        <Card>
+        <Card className="hover:shadow-md transition-shadow duration-200">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">Streaks</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">
               {streakConfig.enabled ? (
-                <span className="text-green-600">Active</span>
+                <span className="text-success">Active</span>
               ) : (
                 <span className="text-muted-foreground">Disabled</span>
               )}
             </div>
           </CardContent>
         </Card>
-        <Card>
+        <Card className="hover:shadow-md transition-shadow duration-200">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">Active Challenges</CardTitle>
           </CardHeader>
@@ -237,7 +237,7 @@ export default function GamificationConfigPage() {
             <div className="text-2xl font-bold">{totalActiveChallenges}</div>
           </CardContent>
         </Card>
-        <Card>
+        <Card className="hover:shadow-md transition-shadow duration-200">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">Max Points / Level</CardTitle>
           </CardHeader>
@@ -456,7 +456,7 @@ export default function GamificationConfigPage() {
                       key={i}
                       className="flex items-center gap-1 rounded-full border px-3 py-1 text-sm"
                     >
-                      <Flame className="h-3 w-3 text-orange-500" />
+                      <Flame className="h-3 w-3 text-warning" />
                       {m} {streakConfig.streakType === "daily" ? "days" : "weeks"}
                     </div>
                   ))}

--- a/src/app/dashboard/@lms_admin/insights/CardStatus.tsx
+++ b/src/app/dashboard/@lms_admin/insights/CardStatus.tsx
@@ -44,9 +44,9 @@ function CardStatus({ title, icon, number, percent, loading }: CardStatusProps) 
           <div className="mt-2">
             <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
               isPositive
-                ? 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                ? 'bg-success/10 text-success'
                 : isNegative
-                  ? 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                  ? 'bg-destructive/10 text-destructive'
                   : 'bg-muted text-muted-foreground'
             }`}>
               {formattedPercent !== 'N/A' ? (

--- a/src/app/dashboard/@lms_admin/insights/courses/InsightsCourse.tsx
+++ b/src/app/dashboard/@lms_admin/insights/courses/InsightsCourse.tsx
@@ -47,14 +47,14 @@ function hslToHex(h: number, s: number, l: number): string {
 }
 
 const ErrorCard = ({ title, error }: { title: string; error: string }) => (
-  <Card className="w-full">
+  <Card className="w-full hover:shadow-md transition-shadow duration-200">
     <CardHeader>
-      <CardTitle className="text-red-500 flex items-center">
+      <CardTitle className="text-destructive flex items-center">
         {title} <CircleX className="ml-2" />
       </CardTitle>
     </CardHeader>
     <CardContent>
-      <p className="text-red-500">{error}</p>
+      <p className="text-destructive">{error}</p>
     </CardContent>
   </Card>
 );
@@ -66,7 +66,7 @@ const BarChartCard = ({
   barChartData: any[];
   dynamicColors: string[];
 }) => (
-  <Card className="w-full flex flex-col justify-between">
+  <Card className="w-full flex flex-col justify-between hover:shadow-md transition-shadow duration-200">
     <CardHeader>
       <CardTitle>New Courses per Month</CardTitle>
     </CardHeader>
@@ -76,7 +76,7 @@ const BarChartCard = ({
           <BarChart data={barChartData}>
             <XAxis dataKey="month" />
             <Tooltip />
-            <Bar dataKey="course_count" fill="#8884d8">
+            <Bar dataKey="course_count" fill="hsl(var(--primary))">
               {barChartData.map((data, index) => (
                 <Cell
                   key={index}
@@ -92,18 +92,18 @@ const BarChartCard = ({
 );
 
 const STATUS_COLORS: Record<string, string> = {
-  Published: '#4BB543',
-  Draft: '#F59E0B',
-  Archived: '#9CA3AF',
+  Published: 'hsl(var(--success))',
+  Draft: 'hsl(var(--warning, 45 93% 47%))',
+  Archived: 'hsl(var(--muted-foreground))',
 };
 
 const CourseStatusPieChart = ({ data }: { data: { name: string; value: number }[] }) => {
   if (!data || data.length === 0) return null;
 
-  const colors = data.map((d) => STATUS_COLORS[d.name] || '#8884d8');
+  const colors = data.map((d) => STATUS_COLORS[d.name] || 'hsl(var(--primary))');
 
   return (
-    <Card className="w-full">
+    <Card className="w-full hover:shadow-md transition-shadow duration-200">
       <CardHeader>
         <CardTitle>Course Status Distribution</CardTitle>
       </CardHeader>
@@ -117,7 +117,7 @@ const CourseStatusPieChart = ({ data }: { data: { name: string; value: number }[
                 cy="50%"
                 labelLine={false}
                 outerRadius={80}
-                fill="#8884d8"
+                fill="hsl(var(--primary))"
                 dataKey="value"
               >
                 {data.map((entry, index) => (
@@ -153,7 +153,7 @@ const PieChartCard = ({
   pieChartData: any[];
   dynamicColors: string[];
 }) => (
-  <Card className="w-full">
+  <Card className="w-full hover:shadow-md transition-shadow duration-200">
     <CardHeader>
       <CardTitle>Courses by Category</CardTitle>
     </CardHeader>
@@ -167,7 +167,7 @@ const PieChartCard = ({
               cy="50%"
               labelLine={false}
               outerRadius={80}
-              fill="#8884d8"
+              fill="hsl(var(--primary))"
               dataKey="value"
             >
               {pieChartData.map((entry, index) => (
@@ -185,7 +185,7 @@ const PieChartCard = ({
         {pieChartData.map((entry, index) => (
           <div key={`legend-${index}`} className="flex items-center">
             <div
-              className="w-3 h-3 mr-1"
+              className="w-3 h-3 mr-1 rounded-full"
               style={{
                 backgroundColor: dynamicColors[index % dynamicColors.length],
               }}

--- a/src/app/dashboard/@lms_admin/leaderboard-config/LeaderboardConfigPage.tsx
+++ b/src/app/dashboard/@lms_admin/leaderboard-config/LeaderboardConfigPage.tsx
@@ -86,21 +86,21 @@ export default function LeaderboardConfigPage() {
 
       {/* Summary Cards */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <Card>
+        <Card className="hover:shadow-md transition-shadow duration-200">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">Status</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">
               {config.enabled ? (
-                <span className="text-green-600">Active</span>
+                <span className="text-success">Active</span>
               ) : (
                 <span className="text-muted-foreground">Disabled</span>
               )}
             </div>
           </CardContent>
         </Card>
-        <Card>
+        <Card className="hover:shadow-md transition-shadow duration-200">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">Visible Entries</CardTitle>
           </CardHeader>
@@ -108,7 +108,7 @@ export default function LeaderboardConfigPage() {
             <div className="text-2xl font-bold">Top {config.showTopN}</div>
           </CardContent>
         </Card>
-        <Card>
+        <Card className="hover:shadow-md transition-shadow duration-200">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">Reset Period</CardTitle>
           </CardHeader>

--- a/src/app/dashboard/@lms_admin/points-config/PointsConfigPage.tsx
+++ b/src/app/dashboard/@lms_admin/points-config/PointsConfigPage.tsx
@@ -24,7 +24,7 @@ const defaultActions: PointAction[] = [
     description: "Awarded when a learner finishes a course",
     points: 100,
     enabled: true,
-    icon: <BookOpen className="h-4 w-4 text-green-600" />,
+    icon: <BookOpen className="h-4 w-4 text-success" />,
   },
   {
     id: "quiz_passed",
@@ -110,7 +110,7 @@ export default function PointsConfigPage() {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <Card>
+        <Card className="hover:shadow-md transition-shadow duration-200">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">Total Actions</CardTitle>
           </CardHeader>
@@ -118,7 +118,7 @@ export default function PointsConfigPage() {
             <div className="text-2xl font-bold">{actions.length}</div>
           </CardContent>
         </Card>
-        <Card>
+        <Card className="hover:shadow-md transition-shadow duration-200">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">Active Actions</CardTitle>
           </CardHeader>
@@ -126,7 +126,7 @@ export default function PointsConfigPage() {
             <div className="text-2xl font-bold">{totalEnabledActions}</div>
           </CardContent>
         </Card>
-        <Card>
+        <Card className="hover:shadow-md transition-shadow duration-200">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium">Max Earnable / Course</CardTitle>
           </CardHeader>

--- a/src/app/dashboard/@org_admin/user-management/addUserDetails.tsx
+++ b/src/app/dashboard/@org_admin/user-management/addUserDetails.tsx
@@ -149,7 +149,7 @@ export default function AddUser({ setOpenAddUser }: { setOpenAddUser: Dispatch<S
                                     render={({ field }) => (
                                         <FormItem>
                                             <Label htmlFor="email" className="font-semibold">
-                                                Email <span className="text-red-500 text-base">*</span>
+                                                Email <span className="text-destructive text-base">*</span>
                                             </Label>
                                             <FormControl>
                                                 <Input placeholder="m@example.com" {...field} />
@@ -164,7 +164,7 @@ export default function AddUser({ setOpenAddUser }: { setOpenAddUser: Dispatch<S
                                     render={({ field }) => (
                                         <FormItem>
                                             <Label htmlFor="name" className="font-semibold">
-                                                Name <span className="text-red-500 text-base">*</span>
+                                                Name <span className="text-destructive text-base">*</span>
                                             </Label>
                                             <FormControl>
                                                 <Input placeholder="John" {...field} />
@@ -292,7 +292,7 @@ export default function AddUser({ setOpenAddUser }: { setOpenAddUser: Dispatch<S
                                     render={({ field }) => (
                                         <FormItem>
                                             <Label htmlFor="group" className="font-semibold">
-                                                Permissions <span className="text-red-500 text-base">*</span>
+                                                Permissions <span className="text-destructive text-base">*</span>
                                             </Label>
                                             <FormControl>
                                                 <Select {...field} onValueChange={value => field.onChange({ target: { value } })}>
@@ -324,7 +324,7 @@ export default function AddUser({ setOpenAddUser }: { setOpenAddUser: Dispatch<S
                                     render={({ field }) => (
                                         <FormItem>
                                             <Label htmlFor="group" className="font-semibold">
-                                                Account Details <span className="text-red-500 text-base">*</span>
+                                                Account Details <span className="text-destructive text-base">*</span>
                                             </Label>
                                             <FormControl>
                                                 <Select {...field} onValueChange={value => field.onChange({ target: { value } })}>

--- a/src/app/dashboard/@super_admin/StatsCard.tsx
+++ b/src/app/dashboard/@super_admin/StatsCard.tsx
@@ -13,18 +13,18 @@ interface StatType {
 
 function StatsCard({ stat }: { stat: StatType }) {
     return (
-        <Card >
+        <Card className="group hover:shadow-md transition-shadow duration-200">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">{stat.title}</CardTitle>
-                <stat.icon className="h-4 w-4 text-muted-foreground" />
+                <stat.icon className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors" />
             </CardHeader>
             <CardContent>
                 <div className="text-2xl font-bold">{stat.value}</div>
                 <p className="text-xs text-muted-foreground">
                     {stat.trend === "up" ? (
-                        <ArrowUpIcon className="inline h-4 w-4 text-green-500" />
+                        <ArrowUpIcon className="inline h-4 w-4 text-success" />
                     ) : (
-                        <ArrowDownIcon className="inline h-4 w-4 text-red-500" />
+                        <ArrowDownIcon className="inline h-4 w-4 text-destructive" />
                     )}
                     {stat.percent} compared to last month
                 </p>

--- a/src/app/dashboard/@super_admin/organizations/OrganizationsForm.tsx
+++ b/src/app/dashboard/@super_admin/organizations/OrganizationsForm.tsx
@@ -130,7 +130,7 @@ export function OrganizationForm({
             <FormItem>
               <FormLabel>
                 Name
-                <span className="text-red-500 text-base">*</span>
+                <span className="text-destructive text-base">*</span>
               </FormLabel>
               <FormControl>
                 <Input placeholder="Organization name" {...field} />
@@ -146,7 +146,7 @@ export function OrganizationForm({
             <FormItem>
               <FormLabel>
                 Domain
-                <span className="text-red-500 text-base">*</span>
+                <span className="text-destructive text-base">*</span>
               </FormLabel>
               <FormControl>
                 <Input placeholder="example.com" {...field} />
@@ -188,7 +188,7 @@ export function OrganizationForm({
                 Upload a PNG or JPG file (max 3 MB)
               </FormDescription>
               {logoError && (
-                <p className="text-sm font-medium text-red-500">{logoError}</p>
+                <p className="text-sm font-medium text-destructive">{logoError}</p>
               )}
             </FormItem>
           )}
@@ -200,7 +200,7 @@ export function OrganizationForm({
             <FormItem>
               <FormLabel>
                 Subscription Package
-                <span className="text-red-500 text-base">*</span>
+                <span className="text-destructive text-base">*</span>
               </FormLabel>
               <Select
                 defaultValue={field.value}

--- a/src/app/dashboard/@super_admin/organizations/addUserDetails.tsx
+++ b/src/app/dashboard/@super_admin/organizations/addUserDetails.tsx
@@ -158,7 +158,7 @@ export default function AddUser({ setOpenAddUser, selectedOrganization }: { setO
                                 render={({ field }) => (
                                     <FormItem>
                                         <Label htmlFor="email" className="font-semibold">
-                                            Email <span className="text-red-500 text-base">*</span>
+                                            Email <span className="text-destructive text-base">*</span>
                                         </Label>
                                         <FormControl>
                                             <Input placeholder="m@example.com" {...field} />
@@ -173,7 +173,7 @@ export default function AddUser({ setOpenAddUser, selectedOrganization }: { setO
                                 render={({ field }) => (
                                     <FormItem>
                                         <Label htmlFor="name" className="font-semibold">
-                                            Name <span className="text-red-500 text-base">*</span>
+                                            Name <span className="text-destructive text-base">*</span>
                                         </Label>
                                         <FormControl>
                                             <Input placeholder="John" {...field} />
@@ -301,7 +301,7 @@ export default function AddUser({ setOpenAddUser, selectedOrganization }: { setO
                                 render={({ field }) => (
                                     <FormItem>
                                         <Label htmlFor="group" className="font-semibold">
-                                            Permissions <span className="text-red-500 text-base">*</span>
+                                            Permissions <span className="text-destructive text-base">*</span>
                                         </Label>
                                         <FormControl>
                                             <Select {...field} onValueChange={value => field.onChange({ target: { value } })}>
@@ -333,7 +333,7 @@ export default function AddUser({ setOpenAddUser, selectedOrganization }: { setO
                                 render={({ field }) => (
                                     <FormItem>
                                         <Label htmlFor="group" className="font-semibold">
-                                            Account Details <span className="text-red-500 text-base">*</span>
+                                            Account Details <span className="text-destructive text-base">*</span>
                                         </Label>
                                         <FormControl>
                                             <Select {...field} onValueChange={value => field.onChange({ target: { value } })}>

--- a/src/app/login/loginForm.tsx
+++ b/src/app/login/loginForm.tsx
@@ -99,7 +99,7 @@ function LoginForm({ domain, registerationEnabled }: { domain: string, registera
      )}
     />
     <LoginButton />
-    {errorMessage && <div className="text-red-500">{errorMessage}</div>}
+    {errorMessage && <div className="text-sm text-destructive">{errorMessage}</div>}
    </form>
    {RegistrationLink}
   </Form>

--- a/src/components/ai/AIConfigForm.tsx
+++ b/src/components/ai/AIConfigForm.tsx
@@ -288,7 +288,7 @@ export function AIConfigForm({ lang = "en" }: AIConfigFormProps) {
           {/* Search */}
           <label className="flex cursor-pointer items-center justify-between rounded-lg border border-muted p-4 transition-colors hover:bg-muted/50">
             <div className="flex items-center gap-3">
-              <Search className="h-5 w-5 text-green-500" />
+              <Search className="h-5 w-5 text-success" />
               <div>
                 <p className="text-sm font-medium text-foreground">
                   {t("AI-Powered Search", "البحث المدعوم بالذكاء الاصطناعي")}
@@ -441,13 +441,13 @@ export function AIConfigForm({ lang = "en" }: AIConfigFormProps) {
       {/* Save Button */}
       <div className="flex items-center justify-end gap-3 pb-8">
         {saveStatus === "success" && (
-          <span className="flex items-center gap-1 text-sm text-green-600">
+          <span className="flex items-center gap-1 text-sm text-success">
             <CheckCircle2 className="h-4 w-4" />
             {t("Saved successfully", "تم الحفظ بنجاح")}
           </span>
         )}
         {saveStatus === "error" && (
-          <span className="flex items-center gap-1 text-sm text-red-600">
+          <span className="flex items-center gap-1 text-sm text-destructive">
             <AlertCircle className="h-4 w-4" />
             {t("Failed to save", "فشل في الحفظ")}
           </span>

--- a/src/components/ai/AISearchResults.tsx
+++ b/src/components/ai/AISearchResults.tsx
@@ -77,9 +77,9 @@ export function AISearchResults({
   };
 
   const levelColors: Record<string, string> = {
-    beginner: "bg-green-100 text-green-700",
-    medium: "bg-yellow-100 text-yellow-700",
-    advanced: "bg-red-100 text-red-700",
+    beginner: "bg-success/10 text-success",
+    medium: "bg-warning/10 text-warning",
+    advanced: "bg-destructive/10 text-destructive",
   };
 
   return (

--- a/src/components/ai/RecommendedCourses.tsx
+++ b/src/components/ai/RecommendedCourses.tsx
@@ -73,9 +73,9 @@ export function RecommendedCourses({
   }
 
   const levelColors: Record<string, string> = {
-    beginner: "bg-green-100 text-green-700",
-    medium: "bg-yellow-100 text-yellow-700",
-    advanced: "bg-red-100 text-red-700",
+    beginner: "bg-success/10 text-success",
+    medium: "bg-warning/10 text-warning",
+    advanced: "bg-destructive/10 text-destructive",
   };
 
   return (

--- a/src/components/auth/MFASetup.tsx
+++ b/src/components/auth/MFASetup.tsx
@@ -291,8 +291,8 @@ export function MFASetup() {
         className="text-center space-y-4"
        >
         <div className="flex justify-center">
-         <div className="rounded-full bg-green-100 p-3">
-          <Check className="w-6 h-6 text-green-600" />
+         <div className="rounded-full bg-success/10 p-3">
+          <Check className="w-6 h-6 text-success" />
          </div>
         </div>
         <h3 className="text-lg font-semibold">Setup Complete!</h3>

--- a/src/components/shared/ExpiredTokenForm.tsx
+++ b/src/components/shared/ExpiredTokenForm.tsx
@@ -19,7 +19,7 @@ export default function ExpiredTokenForm() {
         <CardDescription>Your session has expired. Please log in again to continue.</CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="flex items-center space-x-2 text-yellow-600">
+        <div className="flex items-center space-x-2 text-amber-600 dark:text-amber-400">
           <AlertCircle className="h-5 w-5" />
           <p>Your authentication token has expired due to inactivity.</p>
         </div>

--- a/src/components/shared/TwoColumnLearningOutcomesCard.tsx
+++ b/src/components/shared/TwoColumnLearningOutcomesCard.tsx
@@ -23,7 +23,7 @@ export default function TwoColumnLearningOutcomesCard({ outcomes }: { outcomes: 
         <ul className="md:space-y-2">
             {items.map((outcome) => (
                 <li key={outcome.id} className="flex items-center gap-2 mt-3">
-                    <Check className="w-5 h-5 text-green-500 flex-shrink-0" />
+                    <Check className="w-5 h-5 text-success flex-shrink-0" />
                     <span className="text-foreground text-sm exclude-weglot">{outcome.text}</span>
                 </li>
             ))}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -79,7 +79,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-0 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-0 group-hover:opacity-100 group-[.destructive]:text-destructive-foreground/50 group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive group-[.destructive]:focus:ring-offset-destructive",
       className
     )}
     toast-close=""


### PR DESCRIPTION
…ing pages

Systematically replaced text-red-500, text-green-*, bg-green-100, text-yellow-*, and hex chart colors with semantic tokens (text-destructive, text-success, text-warning, bg-success/10, etc.) for theme consistency and dark mode support. Added hover:shadow-md transitions to summary cards in config pages and StatsCard.

https://claude.ai/code/session_01SC1b8MQuxedfJebyopteX2