### PR TITLE
Replace remaining hardcoded colors with design-system tokens

### DIFF
--- a/src/app/dashboard/@lms_admin/insights/courses/[id]/BarChar.tsx
+++ b/src/app/dashboard/@lms_admin/insights/courses/[id]/BarChar.tsx
@@ -31,8 +31,8 @@ function BarChar({ enrollmentCompletionData, loading, errorMessage }: BarChartPr
                             <YAxis />
                             <Tooltip />
                             <Legend />
-                            <Bar dataKey="enrollments" fill="#8884d8" />
-                            <Bar dataKey="completions" fill="#82ca9d" />
+                            <Bar dataKey="enrollments" fill="hsl(var(--primary))" />
+                            <Bar dataKey="completions" fill="hsl(var(--success))" />
                         </BarChart>
                     </ResponsiveContainer>
                 </div>

--- a/src/app/dashboard/@super_admin/SuperAdminDashboard.tsx
+++ b/src/app/dashboard/@super_admin/SuperAdminDashboard.tsx
@@ -91,28 +91,28 @@ export default function SuperAdminDashboard({
           title="Total Organizations per Month"
           monthlyData={monthlyData}
           type="organizations"
-          color="#8884d8"
+          color="hsl(var(--primary))"
         />
 
         <BarChar
           title="Total Users per Month"
           monthlyData={monthlyData}
           type="users"
-          color="#82ca9d"
+          color="hsl(var(--success))"
         />
 
         <BarChar
           title="Total Courses per Month"
           monthlyData={monthlyData}
           type="courses"
-          color="#ffc658"
+          color="hsl(var(--warning, 45 93% 47%))"
         />
 
         <BarChar
           title="Total Certificates per Month"
           monthlyData={monthlyData}
           type="certificates"
-          color="#ff7300"
+          color="hsl(var(--info))"
         />
       </div>
     </div>

--- a/src/app/welcome/WelcomePage.tsx
+++ b/src/app/welcome/WelcomePage.tsx
@@ -285,10 +285,10 @@ export default function WelcomePage() {
                         <span
                           className={cn(
                             strength === 100
-                              ? "text-green-500"
+                              ? "text-success"
                               : strength > 50
-                                ? "text-yellow-500"
-                                : "text-red-500"
+                                ? "text-warning"
+                                : "text-destructive"
                           )}
                         >
                           {strength === 100

--- a/src/components/ai/AISearchResults.tsx
+++ b/src/components/ai/AISearchResults.tsx
@@ -184,7 +184,7 @@ export function AISearchResults({
                 )}
                 {result.similarity > 0 && (
                   <div className="absolute top-2 flex items-center gap-1 rounded-full bg-background/90 px-2 py-0.5 text-tiny font-medium text-foreground" style={{ [isRTL ? "left" : "right"]: "0.5rem" }}>
-                    <Star className="h-2.5 w-2.5 text-yellow-500" />
+                    <Star className="h-2.5 w-2.5 text-warning" />
                     {Math.round(result.similarity * 100)}%
                   </div>
                 )}


### PR DESCRIPTION
- Password strength indicator: text-green/yellow/red → text-success/warning/destructive
- SuperAdmin charts: hex colors → hsl(var(--primary/success/warning/info))
- Insights BarChar: hex fills → hsl(var(--primary/success))
- AI search star icon: text-yellow-500 → text-warning

https://claude.ai/code/session_01SC1b8MQuxedfJebyopteX2