### PR TITLE
Switch to Google Fonts (Poppins/IBM Plex Sans Arabic) and modernize L…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -166,6 +166,23 @@
   }
   body {
     @apply bg-background text-foreground touch-pan-y antialiased;
+    font-family: var(--font-poppins), var(--font-ibm-arabic), system-ui, sans-serif;
+  }
+
+  /* Arabic text uses IBM Plex Sans Arabic as primary */
+  [dir="rtl"] body,
+  html[lang="ar"] body,
+  [dir="rtl"],
+  html[lang="ar"] {
+    font-family: var(--font-ibm-arabic), var(--font-poppins), system-ui, sans-serif;
+  }
+
+  /* English text uses Poppins as primary */
+  [dir="ltr"] body,
+  html[lang="en"] body,
+  [dir="ltr"],
+  html[lang="en"] {
+    font-family: var(--font-poppins), var(--font-ibm-arabic), system-ui, sans-serif;
   }
 
   body:not(.lang-loaded) {

--- a/src/app/home/learnerDashboard.tsx
+++ b/src/app/home/learnerDashboard.tsx
@@ -12,6 +12,8 @@ import Link from "next/link";
 import { Category, SliderType } from "./types";
 import { useRouter } from "next/navigation";
 import { RecommendedCourses } from "@/components/ai/RecommendedCourses";
+import { Search, ArrowRight, BookOpen, GraduationCap, Compass } from "lucide-react";
+import { useLanguage } from "@/context/language.context";
 
 export default function LearnerDashboard({
   categories,
@@ -26,12 +28,12 @@ export default function LearnerDashboard({
 }) {
 
   const router = useRouter()
+  const { isRTL } = useLanguage();
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
   const [search, setSearch] = useState<string>("");
   const inProgressCourses = courses.filter((course) => course.percentage !== 100);
   const completedCourses = courses.filter((course) => course.percentage === 100);
 
-  // Pick the course closest to completion for the hero
   const heroCourse = useMemo(() => {
     if (inProgressCourses.length === 0) return null;
     return [...inProgressCourses].sort(
@@ -44,21 +46,24 @@ export default function LearnerDashboard({
     .filter((orgCourse) => !selectedCategory || orgCourse.category_id === selectedCategory);
 
   return (
-    <div className="p-4 md:p-6 space-y-0">
-      {/* Search Bar (Visible on Mobile) */}
+    <div className="p-4 md:p-6 space-y-6">
+      {/* Mobile Search */}
       <div className="md:hidden">
-        <Input
-          type="search"
-          placeholder="Search courses..."
-          className="w-full rounded-xl bg-background shadow-sm mb-8 h-11"
-          onChange={(e) => setSearch(e.target.value)}
-          value={search}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              router.push(`/dashboard/search?keyword=${search}`)
-            }
-          }}
-        />
+        <div className="relative">
+          <Search className="absolute start-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            type="search"
+            placeholder={isRTL ? "ابحث عن الدورات..." : "Search courses..."}
+            className="w-full rounded-xl bg-card shadow-sm ps-10 h-11 border-border/50"
+            onChange={(e) => setSearch(e.target.value)}
+            value={search}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                router.push(`/dashboard/search?keyword=${search}`)
+              }
+            }}
+          />
+        </div>
       </div>
 
       {/* Continue Learning Hero */}
@@ -74,31 +79,36 @@ export default function LearnerDashboard({
       {sliders.length > 0 && <Sliders sliders={sliders} />}
 
       {/* Continue Courses Section */}
-      {inProgressCourses.length > 0 ? (
-        <Section title="Continue Courses" link="/dashboard/learn">
+      {inProgressCourses.length > 0 && (
+        <Section
+          title={isRTL ? "أكمل دوراتك" : "Continue Learning"}
+          link="/dashboard/learn"
+          icon={<BookOpen className="h-5 w-5 text-primary" />}
+          isRTL={isRTL}
+        >
           <CourseGrid>
             {inProgressCourses.slice(0, 3).map((course) => (
               <Course key={course.course_id} course={course} />
             ))}
           </CourseGrid>
         </Section>
-      ) : <p>No courses available</p>}
+      )}
 
       {/* AI Recommended Courses */}
-      <div className="mb-8">
-        <RecommendedCourses
-          maxVisible={3}
-          onCourseClick={(courseId) => router.push(`/dashboard/discover?course=${courseId}`)}
-        />
-      </div>
+      <RecommendedCourses
+        maxVisible={3}
+        onCourseClick={(courseId) => router.push(`/dashboard/discover?course=${courseId}`)}
+      />
 
       {/* Achievements & Leaderboard Widgets */}
       <DashboardWidgets />
 
       {/* Discover Courses Section */}
       <Section
-        title="Discover Courses"
+        title={isRTL ? "اكتشف الدورات" : "Discover Courses"}
         link="/dashboard/discover"
+        icon={<Compass className="h-5 w-5 text-primary" />}
+        isRTL={isRTL}
         extraContent={
           <DropdownFilter
             selectedCategory={selectedCategory}
@@ -107,77 +117,97 @@ export default function LearnerDashboard({
           />
         }
       >
-        <CourseGrid>
-          {filteredOrgCourses.length === 0 ? (
-            <p>No courses available</p>
-          ) : (
-            filteredOrgCourses.map((course) => (
+        {filteredOrgCourses.length === 0 ? (
+          <EmptyState
+            message={isRTL ? "لا توجد دورات متاحة حالياً" : "No courses available yet"}
+            subMessage={isRTL ? "تحقق لاحقاً لاكتشاف دورات جديدة" : "Check back later for new courses"}
+          />
+        ) : (
+          <CourseGrid>
+            {filteredOrgCourses.map((course) => (
               <Course key={course.course_id} course={course} />
-            ))
-          )}
-        </CourseGrid>
+            ))}
+          </CourseGrid>
+        )}
       </Section>
 
       {/* Completed Courses Section */}
-      {completedCourses.length > 0 ? (
-        <Section title="Completed Courses"
-          link="/dashboard/learn"
-        >
+      <Section
+        title={isRTL ? "الدورات المكتملة" : "Completed Courses"}
+        link="/dashboard/learn"
+        icon={<GraduationCap className="h-5 w-5 text-success" />}
+        isRTL={isRTL}
+      >
+        {completedCourses.length === 0 ? (
+          <EmptyState
+            message={isRTL ? "لم تكمل أي دورة بعد" : "No completed courses yet"}
+            subMessage={isRTL ? "استمر في التعلم لإكمال دورتك الأولى!" : "Keep learning to complete your first course!"}
+          />
+        ) : (
           <CourseGrid>
             {completedCourses.map((course) => (
               <Course key={`completed-${course.course_id}`} course={course} completed />
             ))}
           </CourseGrid>
-        </Section>
-      ) : <>
-        <Section title="Completed Courses"
-          link="/dashboard/learn"
-        >
-          <p>No courses available</p>
-        </Section>
-      </>}
+        )}
+      </Section>
     </div>
   );
 }
 
-/* Helper Components */
+/* ── Helper Components ── */
 
-// Section Component to avoid repetitive structure
 const Section = ({
   title,
   link,
+  icon,
+  isRTL,
   children,
   extraContent,
 }: {
   title: string;
   link?: string;
+  icon?: React.ReactNode;
+  isRTL?: boolean;
   children: React.ReactNode;
   extraContent?: React.ReactNode;
 }) => (
-  <div className="mb-8">
-    <div className="mb-5 flex flex-col items-start justify-between gap-3 md:flex-row md:items-center">
-      <h2 className="text-xl font-bold tracking-tight md:text-2xl">
-        {title}
-      </h2>
+  <section className="space-y-4">
+    <div className="flex flex-col items-start justify-between gap-3 md:flex-row md:items-center">
+      <div className="flex items-center gap-2.5">
+        {icon}
+        <h2 className="text-xl font-semibold tracking-tight md:text-2xl">
+          {title}
+        </h2>
+      </div>
       <div className="flex items-center gap-2">
         {extraContent}
         {link && (
           <Button
-            variant="outline"
+            variant="ghost"
             size="sm"
-            className="shrink-0 gap-1.5"
+            className="shrink-0 gap-1.5 text-muted-foreground hover:text-primary"
             asChild
           >
-            <Link href={link}>View All</Link>
+            <Link href={link}>
+              {isRTL ? "عرض الكل" : "View All"}
+              <ArrowRight className="h-4 w-4" />
+            </Link>
           </Button>
         )}
       </div>
     </div>
     {children}
-  </div>
+  </section>
 );
 
-// Grid Layout for Courses
 const CourseGrid = ({ children }: { children: React.ReactNode }) => (
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">{children}</div>
+  <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">{children}</div>
+);
+
+const EmptyState = ({ message, subMessage }: { message: string; subMessage: string }) => (
+  <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border/60 bg-muted/30 py-12 px-6 text-center">
+    <p className="text-sm font-medium text-muted-foreground">{message}</p>
+    <p className="mt-1 text-xs text-muted-foreground/70">{subMessage}</p>
+  </div>
 );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 import './globals.css';
-import localFont from 'next/font/local';
+import { Poppins, IBM_Plex_Sans_Arabic } from 'next/font/google';
 import { Toaster } from '@/components/ui/sonner';
 import { Toaster as Toast } from '@/components/ui/toaster';
 import { cn } from '@/lib/utils';
@@ -17,14 +17,18 @@ import {
   getUserDetails,
 } from '@/action/organization/organizationAction';
 
-const localFonts = localFont({
-  src: [
-    { path: '../../public/fonts/light.otf', weight: '300' },
-    { path: '../../public/fonts/regular.otf', weight: '400' },
-    { path: '../../public/fonts/medium.otf', weight: '500' },
-    { path: '../../public/fonts/bold.otf', weight: '700' },
-  ],
-  variable: '--font-ping-font-tlwen',
+const poppins = Poppins({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-poppins',
+  display: 'swap',
+});
+
+const ibmPlexSansArabic = IBM_Plex_Sans_Arabic({
+  subsets: ['arabic'],
+  weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-ibm-arabic',
+  display: 'swap',
 });
 
 export async function generateMetadata() {
@@ -77,7 +81,7 @@ export default async function RootLayout({
       logo: "/logo.png",
       authBackground: "/side.png",
       name: "Entlaqa",
-      primaryColor: "#706efa",
+      primaryColor: "#33658a",
       secondaryColor: "",
       courseExpirationEnabled: false,
       courseExpirationPeriod: 0,
@@ -124,7 +128,7 @@ export default async function RootLayout({
           }, 400)`}
         </Script>
       </head>
-      <body className={cn('min-h-screen bg-background', localFonts.className)}>
+      <body className={cn('min-h-screen bg-background', poppins.variable, ibmPlexSansArabic.variable)}>
         <Suspense>
           <LangugageProvider>
             <SetupProvider

--- a/src/components/app/home/learnerDashboard/ContinueLearningHero.tsx
+++ b/src/components/app/home/learnerDashboard/ContinueLearningHero.tsx
@@ -16,7 +16,7 @@ export default function ContinueLearningHero({ course }: ContinueLearningHeroPro
   const { isRTL } = useLanguage();
 
   return (
-    <div className="relative mb-8 overflow-hidden rounded-2xl bg-gradient-to-r from-primary-900 to-primary-800 shadow-xl">
+    <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-primary-800 via-primary-900 to-primary-800 shadow-lg">
       {/* Background thumbnail */}
       {course.thumbnail && (
         <div className="absolute inset-0">
@@ -24,27 +24,27 @@ export default function ContinueLearningHero({ course }: ContinueLearningHeroPro
             src={course.thumbnail}
             alt=""
             fill
-            className="object-cover opacity-20"
+            className="object-cover opacity-15 blur-sm"
             sizes="(max-width: 768px) 100vw, 70vw"
           />
-          <div className="absolute inset-0 bg-gradient-to-r from-primary-900/90 via-primary-900/70 to-primary-800/50" />
+          <div className="absolute inset-0 bg-gradient-to-br from-primary-900/95 via-primary-900/80 to-primary-800/70" />
         </div>
       )}
 
-      {/* Decorative elements */}
-      <div className="absolute top-0 end-0 w-64 h-64 bg-gradient-to-bl from-accent/20 to-transparent rounded-full -translate-y-1/2 translate-x-1/2 blur-3xl" />
-      <div className="absolute bottom-0 start-0 w-48 h-48 bg-gradient-to-tr from-primary/30 to-transparent rounded-full translate-y-1/2 -translate-x-1/2 blur-2xl" />
+      {/* Decorative accents */}
+      <div className="absolute -top-20 -end-20 h-64 w-64 rounded-full bg-accent/10 blur-3xl" />
+      <div className="absolute -bottom-16 -start-16 h-48 w-48 rounded-full bg-primary-400/10 blur-3xl" />
 
       {/* Content */}
-      <div className="relative flex flex-col gap-4 p-6 md:flex-row md:items-center md:gap-8 md:p-8">
+      <div className="relative flex flex-col gap-5 p-6 md:flex-row md:items-center md:gap-8 md:p-8">
         {/* Thumbnail preview */}
         <div className="hidden shrink-0 md:block">
-          <div className="h-32 w-48 overflow-hidden rounded-xl shadow-2xl ring-1 ring-white/10">
+          <div className="h-[120px] w-[180px] overflow-hidden rounded-xl shadow-2xl ring-1 ring-white/10">
             <Image
               src={course.thumbnail || ""}
               alt={course.name || ""}
-              width={192}
-              height={128}
+              width={180}
+              height={120}
               className="h-full w-full object-cover"
             />
           </div>
@@ -53,15 +53,15 @@ export default function ContinueLearningHero({ course }: ContinueLearningHeroPro
         {/* Info */}
         <div className="flex-1 min-w-0">
           <div className="mb-2 flex items-center gap-2">
-            <Sparkles className="h-3.5 w-3.5 text-warning" />
-            <p className="text-xs font-semibold uppercase tracking-widest text-primary-foreground/80">
+            <Sparkles className="h-3.5 w-3.5 text-amber-400" />
+            <p className="text-[11px] font-semibold uppercase tracking-widest text-white/60">
               {isRTL ? "أكمل التعلم" : "Continue Learning"}
             </p>
           </div>
-          <h2 className="mb-2 text-xl font-bold text-primary-foreground md:text-2xl line-clamp-1 exclude-weglot" dir="auto">
+          <h2 className="mb-1.5 text-lg font-bold text-white md:text-xl line-clamp-1 exclude-weglot" dir="auto">
             {course.name}
           </h2>
-          <p className="mb-4 text-sm text-primary-foreground/60 exclude-weglot">
+          <p className="mb-4 text-xs text-white/50 exclude-weglot">
             {isRTL ? course.category_ar_name : course.category_name}
           </p>
 
@@ -69,10 +69,10 @@ export default function ContinueLearningHero({ course }: ContinueLearningHeroPro
           <div className="flex items-center gap-3">
             <Progress
               value={course.percentage ?? 0}
-              className="h-2.5 flex-1 bg-primary-foreground/15"
-              progressClassName="bg-gradient-to-r from-primary-foreground/90 to-primary-foreground/70"
+              className="h-2 flex-1 bg-white/10"
+              progressClassName="bg-white/80"
             />
-            <span className="shrink-0 rounded-full bg-primary-foreground/15 px-3 py-1 text-xs font-bold text-primary-foreground">
+            <span className="shrink-0 rounded-full bg-white/10 px-2.5 py-0.5 text-xs font-semibold text-white">
               {course.percentage ?? 0}%
             </span>
           </div>
@@ -83,10 +83,10 @@ export default function ContinueLearningHero({ course }: ContinueLearningHeroPro
           <Link href={`/dashboard/course/play/${course.slug}`}>
             <Button
               size="lg"
-              className="w-full gap-2 bg-primary-foreground text-primary-900 hover:bg-primary-foreground/90 shadow-lg md:w-auto font-semibold"
+              className="w-full gap-2 bg-white text-primary-900 hover:bg-white/90 shadow-lg md:w-auto font-semibold"
             >
               <Play className="h-4 w-4" />
-              {isRTL ? "استئناف التعلم" : "Resume Learning"}
+              {isRTL ? "استئناف التعلم" : "Resume"}
             </Button>
           </Link>
         </div>

--- a/src/components/app/home/learnerDashboard/Course.tsx
+++ b/src/components/app/home/learnerDashboard/Course.tsx
@@ -27,75 +27,73 @@ function Course({
   const percentage = course?.percentage ?? -1;
 
   return (
-    <>
-      <Card key={course?.id} className="group overflow-hidden card-hover">
-        <CardHeader className="exclude-weglot p-0 mb-4">
-          {/* Image with hover zoom + gradient overlay */}
-          <div className="relative overflow-hidden rounded-t-xl">
-            <Image
-              src={course?.thumbnail || ""}
-              width={400}
-              height={225}
-              alt={course?.name || "course"}
-              layout="responsive"
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-              loading="lazy"
-              className="aspect-video w-full object-cover transition-transform duration-500 group-hover:scale-105"
-            />
-            {/* Gradient overlay on hover */}
-            <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+    <Card key={course?.id} className="group overflow-hidden border border-border/50 shadow-sm transition-all duration-300 hover:shadow-lg hover:-translate-y-0.5">
+      <CardHeader className="exclude-weglot p-0">
+        {/* Image with hover zoom + gradient overlay */}
+        <div className="relative overflow-hidden">
+          <Image
+            src={course?.thumbnail || ""}
+            width={400}
+            height={225}
+            alt={course?.name || "course"}
+            layout="responsive"
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            loading="lazy"
+            className="aspect-video w-full object-cover transition-transform duration-500 group-hover:scale-105"
+          />
+          {/* Gradient overlay on hover */}
+          <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
 
-            {/* Category badge floating on image */}
-            <div className="absolute top-3 start-3 z-10">
-              <Badge variant="secondary" className="bg-card/90 backdrop-blur-sm text-xs font-medium shadow-sm">
-                {isRTL ? course?.category_ar_name : course?.category_name}
+          {/* Category badge floating on image */}
+          <div className="absolute top-3 start-3 z-10">
+            <Badge variant="secondary" className="bg-card/90 backdrop-blur-sm text-[11px] font-medium shadow-sm border-0">
+              {isRTL ? course?.category_ar_name : course?.category_name}
+            </Badge>
+          </div>
+
+          {/* Progress badge on image (if in progress) */}
+          {percentage >= 0 && (
+            <div className="absolute top-3 end-3 z-10">
+              <Badge
+                variant={completed ? "success" : "secondary"}
+                className={completed
+                  ? "shadow-sm"
+                  : "bg-card/90 backdrop-blur-sm shadow-sm border-0"
+                }
+              >
+                {completed ? (isRTL ? "مكتمل" : "Completed") : `${percentage}%`}
               </Badge>
             </div>
-
-            {/* Progress badge on image (if in progress) */}
-            {percentage >= 0 && (
-              <div className="absolute top-3 end-3 z-10">
-                <Badge
-                  variant={completed ? "success" : "secondary"}
-                  className={completed
-                    ? "shadow-sm"
-                    : "bg-card/90 backdrop-blur-sm shadow-sm"
-                  }
-                >
-                  {completed ? "Completed" : `${percentage}%`}
-                </Badge>
-              </div>
-            )}
-          </div>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <h3 dir="auto" className="font-semibold leading-tight line-clamp-2 group-hover:text-primary transition-colors duration-200 exclude-weglot">
-            {isFullCourseType(course) ? course.title : course.name}
-          </h3>
-
-          {percentage < 0 ? (
-            <ReadMore
-              id={course?.id?.toString() ?? ''}
-              text={course?.description as string}
-              amountOfWords={17}
-            />
-          ) : (
-            <div className="space-y-1.5">
-              <Progress
-                value={percentage}
-                className="h-2 w-full"
-                gradient={percentage > 50}
-                progressClassName={completed ? "bg-success" : undefined}
-              />
-              <div className="flex items-center justify-between text-xs text-muted-foreground">
-                <span>{percentage}% complete</span>
-              </div>
-            </div>
           )}
-          <CourseButtonActions course={course} completed={completed} />
-        </CardContent>
-      </Card>
-    </>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3 p-4">
+        <h3 dir="auto" className="font-semibold text-sm leading-tight line-clamp-2 group-hover:text-primary transition-colors duration-200 exclude-weglot">
+          {isFullCourseType(course) ? course.title : course.name}
+        </h3>
+
+        {percentage < 0 ? (
+          <ReadMore
+            id={course?.id?.toString() ?? ''}
+            text={course?.description as string}
+            amountOfWords={17}
+          />
+        ) : (
+          <div className="space-y-1.5">
+            <Progress
+              value={percentage}
+              className="h-1.5 w-full"
+              gradient={percentage > 50}
+              progressClassName={completed ? "bg-success" : undefined}
+            />
+            <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+              <span>{percentage}% {isRTL ? "مكتمل" : "complete"}</span>
+            </div>
+          </div>
+        )}
+        <CourseButtonActions course={course} completed={completed} />
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/components/app/home/learnerDashboard/DashboardWidgets.tsx
+++ b/src/components/app/home/learnerDashboard/DashboardWidgets.tsx
@@ -2,7 +2,7 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Trophy, Target, ChevronRight, Sparkles } from "lucide-react";
+import { Trophy, Target, ArrowRight } from "lucide-react";
 import Link from "next/link";
 import { useLanguage } from "@/context/language.context";
 import {
@@ -14,7 +14,6 @@ import {
   type LeaderboardEntry,
 } from "@/components/gamification/LeaderboardComponents";
 
-// Mock challenges — will be replaced with real data in Phase 2
 const MOCK_CHALLENGES: ChallengeData[] = [
   {
     id: "ch-1",
@@ -42,7 +41,6 @@ const MOCK_CHALLENGES: ChallengeData[] = [
   },
 ];
 
-// Mock leaderboard — will be replaced with real data in Phase 2
 const MOCK_LEADERBOARD: LeaderboardEntry[] = [
   { rank: 1, userId: "u1", displayName: "Sarah A.", totalXP: 4200, currentLevel: 8, levelName: "Grand Master", levelColor: "bg-destructive", currentStreak: 14 },
   { rank: 2, userId: "u2", displayName: "Ahmed K.", totalXP: 3800, currentLevel: 7, levelName: "Master", levelColor: "bg-warning", currentStreak: 9 },
@@ -55,24 +53,24 @@ export default function DashboardWidgets() {
   const { isRTL } = useLanguage();
 
   return (
-    <div className="mb-8 grid grid-cols-1 gap-6 lg:grid-cols-2">
+    <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
       {/* Challenges Widget */}
-      <Card className="group overflow-hidden">
-        <CardHeader className="flex flex-row items-center justify-between pb-3">
-          <CardTitle className="flex items-center gap-2 text-base">
+      <Card className="overflow-hidden border border-border/50">
+        <CardHeader className="flex flex-row items-center justify-between pb-2 pt-5 px-5">
+          <CardTitle className="flex items-center gap-2.5 text-sm font-semibold">
             <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
               <Target className="h-4 w-4 text-primary" />
             </div>
             {isRTL ? "التحديات النشطة" : "Active Challenges"}
           </CardTitle>
           <Link href="/dashboard/achievements">
-            <Button variant="ghost" size="sm" className="gap-1 text-xs text-muted-foreground hover:text-primary">
+            <Button variant="ghost" size="sm" className="gap-1 text-xs text-muted-foreground hover:text-primary h-8">
               {isRTL ? "عرض الكل" : "View All"}
-              <ChevronRight className="h-3.5 w-3.5" />
+              <ArrowRight className="h-3.5 w-3.5" />
             </Button>
           </Link>
         </CardHeader>
-        <CardContent className="space-y-3">
+        <CardContent className="space-y-3 px-5 pb-5">
           {MOCK_CHALLENGES.map((challenge) => (
             <ChallengeCard key={challenge.id} challenge={challenge} />
           ))}
@@ -80,22 +78,22 @@ export default function DashboardWidgets() {
       </Card>
 
       {/* Leaderboard Preview Widget */}
-      <Card className="group overflow-hidden">
-        <CardHeader className="flex flex-row items-center justify-between pb-3">
-          <CardTitle className="flex items-center gap-2 text-base">
-            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-warning/10">
-              <Trophy className="h-4 w-4 text-warning" />
+      <Card className="overflow-hidden border border-border/50">
+        <CardHeader className="flex flex-row items-center justify-between pb-2 pt-5 px-5">
+          <CardTitle className="flex items-center gap-2.5 text-sm font-semibold">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-amber-500/10">
+              <Trophy className="h-4 w-4 text-amber-500" />
             </div>
             {isRTL ? "لوحة المتصدرين" : "Leaderboard"}
           </CardTitle>
           <Link href="/dashboard/leaderboard">
-            <Button variant="ghost" size="sm" className="gap-1 text-xs text-muted-foreground hover:text-primary">
+            <Button variant="ghost" size="sm" className="gap-1 text-xs text-muted-foreground hover:text-primary h-8">
               {isRTL ? "عرض الكل" : "View All"}
-              <ChevronRight className="h-3.5 w-3.5" />
+              <ArrowRight className="h-3.5 w-3.5" />
             </Button>
           </Link>
         </CardHeader>
-        <CardContent className="space-y-2">
+        <CardContent className="space-y-1.5 px-5 pb-5">
           {MOCK_LEADERBOARD.map((entry) => (
             <LeaderboardRow key={entry.userId} entry={entry} showStreak={false} />
           ))}

--- a/src/components/app/home/learnerDashboard/StatsRow.tsx
+++ b/src/components/app/home/learnerDashboard/StatsRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Card, CardContent } from "@/components/ui/card";
-import { Flame, Clock, CheckCircle2, BarChart3 } from "lucide-react";
+import { Flame, Clock, CheckCircle2, Trophy } from "lucide-react";
 import { useLanguage } from "@/context/language.context";
 
 interface StatsRowProps {
@@ -17,50 +17,47 @@ export default function StatsRow({ completedCount, inProgressCount }: StatsRowPr
       icon: Flame,
       value: 7,
       label: isRTL ? "أيام متتالية" : "Day Streak",
-      color: "text-warning",
-      bgColor: "bg-warning/10",
-      borderColor: "from-warning/50 to-warning/10",
+      color: "text-orange-500",
+      bgColor: "bg-orange-500/10",
     },
     {
       icon: Clock,
       value: `${Math.max(1, Math.round((completedCount * 4 + inProgressCount * 2)))}h`,
       label: isRTL ? "ساعات التعلم" : "Learning Hours",
-      color: "text-info",
-      bgColor: "bg-info/10",
-      borderColor: "from-info/50 to-info/10",
+      color: "text-blue-500",
+      bgColor: "bg-blue-500/10",
     },
     {
       icon: CheckCircle2,
       value: completedCount,
       label: isRTL ? "دورات مكتملة" : "Completed",
-      color: "text-success",
-      bgColor: "bg-success/10",
-      borderColor: "from-success/50 to-success/10",
+      color: "text-emerald-500",
+      bgColor: "bg-emerald-500/10",
     },
     {
-      icon: BarChart3,
+      icon: Trophy,
       value: "#5",
       label: isRTL ? "الترتيب" : "Leaderboard",
-      color: "text-accent",
-      bgColor: "bg-accent/10",
-      borderColor: "from-accent/50 to-accent/10",
+      color: "text-amber-500",
+      bgColor: "bg-amber-500/10",
     },
   ];
 
   return (
-    <div className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-4">
-      {stats.map((stat) => (
-        <Card key={stat.label} className="group relative overflow-hidden border-0 shadow-sm card-hover">
-          {/* Top accent bar */}
-          <div className={`absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r ${stat.borderColor}`} />
-
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
+      {stats.map((stat, index) => (
+        <Card
+          key={stat.label}
+          className="group relative overflow-hidden border border-border/50 shadow-sm transition-shadow duration-300 hover:shadow-md"
+          style={{ animationDelay: `${index * 80}ms` }}
+        >
           <CardContent className="flex items-center gap-3 p-4">
-            <div className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl ${stat.bgColor} transition-transform duration-300 group-hover:scale-110`}>
-              <stat.icon className={`h-5 w-5 ${stat.color}`} />
+            <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${stat.bgColor} transition-transform duration-300 group-hover:scale-110`}>
+              <stat.icon className={`h-[18px] w-[18px] ${stat.color}`} />
             </div>
             <div className="min-w-0">
-              <p className="text-xl font-bold leading-tight tracking-tight">{stat.value}</p>
-              <p className="text-xs text-muted-foreground truncate">{stat.label}</p>
+              <p className="text-lg font-bold leading-tight tracking-tight">{stat.value}</p>
+              <p className="text-[11px] text-muted-foreground truncate">{stat.label}</p>
             </div>
           </CardContent>
         </Card>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,6 +18,11 @@ const config = {
       },
     },
     extend: {
+      fontFamily: {
+        sans: ['var(--font-poppins)', 'var(--font-ibm-arabic)', 'system-ui', 'sans-serif'],
+        poppins: ['var(--font-poppins)', 'system-ui', 'sans-serif'],
+        arabic: ['var(--font-ibm-arabic)', 'system-ui', 'sans-serif'],
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
…earner Dashboard

Fonts:
- Replace local OTF fonts with next/font/google Poppins (English) and IBM Plex Sans Arabic (Arabic), loaded with display:swap for no FOIT
- Add CSS font-family rules keyed off dir/lang attributes so Arabic pages lead with IBM Plex Sans Arabic and English pages lead with Poppins
- Register font-sans/font-poppins/font-arabic families in Tailwind config
- Fix layout.tsx fallback primaryColor (#706efa → #33658a)

Learner Dashboard modernization:
- Rework main orchestrator with proper section icons, localized section titles, ghost "View All" links, and a dashed empty-state placeholder
- Refine StatsRow: softer borders, staggered hover, cleaner icon colors
- Simplify ContinueLearningHero: tighter padding, subtler blur/glow, white CTA button for better contrast
- Polish Course card: thinner progress bars, lighter borders, smaller text for completion % labels
- Clean up DashboardWidgets: consistent card padding, arrow-right links

https://claude.ai/code/session_01SC1b8MQuxedfJebyopteX2