### PR TITLE
Fix null subscriptionExpirationDate crash on Organizations page

### DIFF
--- a/src/action/super-admin/orgnizations/organizationsActions.ts
+++ b/src/action/super-admin/orgnizations/organizationsActions.ts
@@ -28,9 +28,9 @@ export const getOrganizations = async () => {
       allowedCourses: org.allowed_courses,
       totalContentCreators: org.total_content_creators,
       allowedContentCreators: org.allowed_content_creators,
-      subscriptionExpirationDate: new Date(org.subscription_expiration_date),
+      subscriptionExpirationDate: org.subscription_expiration_date ? new Date(org.subscription_expiration_date) : null,
       status:
-        new Date() <= new Date(org.subscription_expiration_date)
+        org.subscription_expiration_date && new Date() <= new Date(org.subscription_expiration_date)
           ? "Active"
           : "Expired",
       allowCreateCourses: org.create_courses,

--- a/src/action/super-admin/orgnizations/type.ts
+++ b/src/action/super-admin/orgnizations/type.ts
@@ -9,7 +9,7 @@ export interface Organization {
   allowedCourses: number;
   totalContentCreators: number;
   allowedContentCreators: number;
-  subscriptionExpirationDate: Date;
+  subscriptionExpirationDate: Date | null;
   status: 'Active' | 'Expired';
   allowCreateCourses: boolean;
   allowCreateAICourses: boolean;

--- a/src/app/dashboard/@super_admin/organizations/OrganizationsPage.tsx
+++ b/src/app/dashboard/@super_admin/organizations/OrganizationsPage.tsx
@@ -74,9 +74,9 @@ export default function OrganizationsPage({
         allowedCourses: org.allowedCourses,
         totalContentCreators: org.totalContentCreators,
         allowedContentCreators: org.allowedContentCreators,
-        subscriptionExpirationDate: new Date(org.subscriptionExpirationDate),
+        subscriptionExpirationDate: org.subscriptionExpirationDate ? new Date(org.subscriptionExpirationDate) : null,
         status:
-          new Date() <= new Date(org.subscriptionExpirationDate)
+          org.subscriptionExpirationDate && new Date() <= new Date(org.subscriptionExpirationDate)
             ? "Active"
             : "Disabled",
         allowCreateCourses: org.createCourses,

--- a/src/app/dashboard/@super_admin/organizations/columns.tsx
+++ b/src/app/dashboard/@super_admin/organizations/columns.tsx
@@ -209,7 +209,7 @@ export const columns: ColumnDef<Organization>[] = [
         },
         cell: ({ row }) => (
             <div className="flex items-center justify-center exclude-weglot ">
-                {row.original.subscriptionExpirationDate.toLocaleDateString()}
+                {row.original.subscriptionExpirationDate?.toLocaleDateString() ?? "N/A"}
                 <span
                     className={`ms-2 w-2 h-2 rounded-full ${row.original.status === "Active" ? "bg-success" : "bg-destructive"
                         }`}

--- a/src/app/dashboard/@super_admin/organizations/type.ts
+++ b/src/app/dashboard/@super_admin/organizations/type.ts
@@ -10,7 +10,7 @@ export interface Organization {
   allowedCourses: number;
   totalContentCreators: number;
   allowedContentCreators: number;
-  subscriptionExpirationDate: Date;
+  subscriptionExpirationDate: Date | null;
   status: 'Active' | 'Expired';
   allowCreateCourses: boolean;
   allowCreateAICourses: boolean;


### PR DESCRIPTION
Handle null subscription_expiration_date by adding null checks in data mapping and optional chaining in the column renderer. Shows "N/A" when no expiration date exists.

https://claude.ai/code/session_01SC1b8MQuxedfJebyopteX2