### PR TITLE
Fix migration: set datestyle=DMY before TEXT→TIMESTAMPTZ cast

### DIFF
--- a/supabase/migrations/20260223110000_subscription_management.sql
+++ b/supabase/migrations/20260223110000_subscription_management.sql
@@ -3,9 +3,15 @@
 -- ==========================================================================
 
 -- 1. Convert start_date & expires_at from TEXT to TIMESTAMPTZ
+--    Existing data may use locale-dependent formats (e.g. "22/02/2026 ..."),
+--    so we set datestyle to handle DD/MM/YYYY before the cast.
+SET datestyle = 'ISO, DMY';
+
 ALTER TABLE public.subscriptions
   ALTER COLUMN start_date  TYPE timestamptz USING start_date::timestamptz,
   ALTER COLUMN expires_at  TYPE timestamptz USING expires_at::timestamptz;
+
+RESET datestyle;
 
 -- 2. Add is_active flag (existing rows default to true)
 ALTER TABLE public.subscriptions


### PR DESCRIPTION
Existing subscription dates use DD/MM/YYYY format from now()::text, which fails the default timestamptz cast. Setting datestyle to DMY before the ALTER ensures correct parsing.

https://claude.ai/code/session_01SC1b8MQuxedfJebyopteX2