### PR TITLE
Fix admin course creation and category page by switching to get_user_…

### DIFF
--- a/src/__tests__/unit/auth/fetchUserData.test.ts
+++ b/src/__tests__/unit/auth/fetchUserData.test.ts
@@ -14,15 +14,15 @@ describe('fetchUserData', () => {
   })
 
   it('returns user data on successful RPC call', async () => {
-    const userData = { user_role: 'learner', is_active: true }
+    const rpcRow = { role: 'learner', is_active: true, organization_id: 1 }
     mockSupabase.rpc.mockReturnValueOnce({
-      data: [userData],
+      data: [rpcRow],
       error: null,
     })
 
     const result = await fetchUserData()
-    expect(result).toEqual(userData)
-    expect(mockSupabase.rpc).toHaveBeenCalledWith('get_user_role')
+    expect(result).toEqual({ ...rpcRow, user_role: 'learner' })
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('get_user_details')
   })
 
   it('returns null when RPC returns error', async () => {

--- a/src/action/authAction.ts
+++ b/src/action/authAction.ts
@@ -9,20 +9,20 @@ export async function fetchUserData() {
   try {
     const supabase = await createClient();
 
-    let { data, error } = await supabase.rpc('get_user_role');
+    let { data, error } = await supabase.rpc('get_user_details');
 
     if (error) {
-      console.error('Error fetching user role:', error);
+      console.error('Error fetching user details:', error);
       return null;
     }
 
     if (!data || data.length === 0) {
-      console.log('No role data returned');
+      console.log('No user data returned');
       return null;
     }
 
-    // Assuming `data` is a single value like a string
-    return data[0];
+    const row = data[0];
+    return { ...row, user_role: row.role };
   } catch {
     return null;
   }


### PR DESCRIPTION
…details RPC

fetchUserData() was calling get_user_role() which returns a plain TEXT string, but every caller destructures { user_role, organization_id, is_active } from it. This caused the category page and add-course page to crash for LMS admins.

Switched to get_user_details() RPC which returns the full user row, and map the `role` field to `user_role` for backward compatibility with all callers.

https://claude.ai/code/session_01SC1b8MQuxedfJebyopteX2