### PR TITLE
Fix Add New Course button disabled: unwrap RPC array in getOrganizati…

### DIFF
--- a/src/action/organization/organizationAction.ts
+++ b/src/action/organization/organizationAction.ts
@@ -12,7 +12,7 @@ export async function getOrganizationDetails(domain: string) {
     if (error) {
       return null
     };
-    return data;
+    return data?.[0] ?? null;
   } catch {
     return null;
   }


### PR DESCRIPTION
…onDetails

get_organization_settings_for_user returns TABLE (array via PostgREST), but SetupProvider accesses the result as a single object (e.g. organizationDetails.organization_id). Since arrays lack these properties, organization_id in Redux was always undefined, causing getAiAndDocumentBuilder(undefined) to return no row — so create_courses was never read and the button stayed disabled.

Fix: return data?.[0] instead of the raw array.

https://claude.ai/code/session_01SC1b8MQuxedfJebyopteX2