### PR TITLE
Fix courses page 500: drop ambiguous function overloads, add null-saf…

### DIFF
--- a/src/app/api/scorm/content/[...path]/route.ts
+++ b/src/app/api/scorm/content/[...path]/route.ts
@@ -39,7 +39,8 @@ export const GET = async (
   console.log('🔍 Request params:', params);
   const courseSlug = params.path[0];
   const searchPath = params.path.slice(1).join("/");
-  const { organization_id } = await fetchUserData();
+  const userData = await fetchUserData();
+  const organization_id = userData?.organization_id;
 
 
   try {

--- a/src/app/dashboard/@lms_admin/(courses_categorise)/categories/page.tsx
+++ b/src/app/dashboard/@lms_admin/(courses_categorise)/categories/page.tsx
@@ -10,7 +10,8 @@ interface SearchParams {
 }
 
 async function page({searchParams}: {searchParams: SearchParams}) {
-  const { user_role } = await fetchUserData();
+  const userData = await fetchUserData();
+  const user_role = userData?.user_role ?? '';
   if (user_role !== 'LMSAdmin') {
     return redirect('/dashboard/courses')
   }

--- a/src/app/dashboard/@lms_admin/(courses_categorise)/courses/add-course/page.tsx
+++ b/src/app/dashboard/@lms_admin/(courses_categorise)/courses/add-course/page.tsx
@@ -8,7 +8,9 @@ import { getAiAndDocumentBuilder } from "@/action/organization/organizationActio
 
 
 async function CourseDetailsPage() {
-    const { user_role, organization_id } = await fetchUserData();
+    const userData = await fetchUserData();
+    const user_role = userData?.user_role ?? '';
+    const organization_id = userData?.organization_id;
     if (user_role !== 'LMSAdmin') {
         return redirect('/dashboard/courses')
     }

--- a/src/app/dashboard/@lms_admin/(courses_categorise)/courses/edit-content/page.tsx
+++ b/src/app/dashboard/@lms_admin/(courses_categorise)/courses/edit-content/page.tsx
@@ -11,7 +11,9 @@ type OrganizationFeatures = {
 };
 
 async function EditContentPage({ searchParams }: { searchParams: { co: string } }) {
-  const { user_role, organization_id } = await fetchUserData();
+  const userData = await fetchUserData();
+  const user_role = userData?.user_role ?? '';
+  const organization_id = userData?.organization_id;
   if (user_role !== 'LMSAdmin') {
     return redirect('/dashboard/courses')
   }

--- a/src/app/dashboard/@lms_admin/(courses_categorise)/courses/edit-course/[id]/page.tsx
+++ b/src/app/dashboard/@lms_admin/(courses_categorise)/courses/edit-course/[id]/page.tsx
@@ -24,7 +24,9 @@ async function page({ params }: { params: { id: string } }) {
         const baseUrl = process.env.NODE_ENV === 'development' ? `http://${host}` : `https://${host}`
         
         // Check user role
-        const { user_role, organization_id } = await fetchUserData();
+        const userData = await fetchUserData();
+        const user_role = userData?.user_role ?? '';
+        const organization_id = userData?.organization_id;
         if (user_role !== 'LMSAdmin') {
             redirect('/dashboard/courses')
         }

--- a/src/app/dashboard/@lms_admin/(courses_categorise)/courses/page.tsx
+++ b/src/app/dashboard/@lms_admin/(courses_categorise)/courses/page.tsx
@@ -4,7 +4,8 @@ import { CSVButton } from "./CSVButton";
 
 export const dynamic = 'force-dynamic'
 async function CoursePage({ searchParams }: { searchParams: { page?: string, course?: string, department?: string } }) {
-  const { user_role } = await fetchUserData();
+  const userData = await fetchUserData();
+  const user_role = userData?.user_role ?? '';
   return (
     <div className="flex flex-col p-6">
       <div className="flex items-center justify-between">

--- a/src/app/dashboard/@lms_admin/(courses_categorise)/courses/preview-content/page.tsx
+++ b/src/app/dashboard/@lms_admin/(courses_categorise)/courses/preview-content/page.tsx
@@ -9,7 +9,9 @@ interface OrganizationFeatures {
 
 
 async function PreviewContentPage({ searchParams }: { searchParams: { co: string } }) {
-  const { user_role, organization_id } = await fetchUserData();
+  const userData = await fetchUserData();
+  const user_role = userData?.user_role ?? '';
+  const organization_id = userData?.organization_id;
   if (user_role !== 'LMSAdmin') {
     return redirect('/dashboard/courses')
   }

--- a/supabase/migrations/20260222000000_course_status_tracking.sql
+++ b/supabase/migrations/20260222000000_course_status_tracking.sql
@@ -55,6 +55,9 @@ CREATE POLICY "Authenticated users can insert audit logs"
 -- ============================================================
 -- 3. Updated get_all_courses RPC (with _status_filter)
 -- ============================================================
+-- Drop the old 2-param overload so PostgREST doesn't see ambiguous signatures
+DROP FUNCTION IF EXISTS public.get_all_courses(text, text);
+
 CREATE OR REPLACE FUNCTION public.get_all_courses(
   _name_filter     text DEFAULT NULL,
   _category_filter text DEFAULT NULL,
@@ -93,6 +96,9 @@ $$;
 -- ============================================================
 -- 4. Updated get_enrollment_activity RPC (with enrollment_status)
 -- ============================================================
+-- Drop the old 6-param overload so PostgREST doesn't see ambiguous signatures
+DROP FUNCTION IF EXISTS public.get_enrollment_activity(text, text, text, text, text, text);
+
 CREATE OR REPLACE FUNCTION public.get_enrollment_activity(
   _name              text DEFAULT NULL,
   _course            text DEFAULT NULL,


### PR DESCRIPTION
…e fetchUserData

Two issues fixed:

1. get_all_courses and get_enrollment_activity had duplicate overloads (2-param from baseline + 3-param from course_status_tracking migration). Both had DEFAULT NULL on all params, causing PostgREST ambiguity → 500. Added DROP FUNCTION before CREATE to remove the old signatures.

2. All 7 pages that destructure fetchUserData() now use null-safe access (userData?.user_role) instead of direct destructuring which throws TypeError if the RPC returns null.

https://claude.ai/code/session_01SC1b8MQuxedfJebyopteX2