### PR TITLE
Fix courses/categories 500: safe error handling + RPC-based category …

### DIFF
--- a/src/action/categories/categoriesActions.ts
+++ b/src/action/categories/categoriesActions.ts
@@ -50,25 +50,39 @@ const fetchDataById = async (rpcName: string, params: object) => { // Changed co
 };
 
 export const fetchAllCategories = async () => {
-    const supabase = await createClient();
-    const { data, error } = await supabase.rpc('get_all_categories', {
-        _name_filter: null,
-    });
-    if (error) {
-        throw new Error(`Error fetching categories: ${error.message}`);
+    try {
+        const supabase = await createClient();
+        const { data, error } = await supabase.rpc('get_all_categories', {
+            _name_filter: null,
+        });
+        if (error) {
+            console.error('Error fetching categories:', error.message);
+            return [];
+        }
+        return data ?? [];
+    } catch (error: any) {
+        console.error('Error fetching categories:', error.message);
+        return [];
     }
-    return data;
 }
 export const fetchAllCategoriesFiltered = async (filters: any, page: number, pageSize: number) => {
-    const supabase = await createClient();
+    try {
+        const supabase = await createClient();
+        const start = (page - 1) * pageSize;
+        const end = start + pageSize - 1;
 
-    const { data, error, count } = await supabase.rpc('get_all_categories', {
-        _name_filter: filters.name ?? null,
-    }, { count: 'exact' }).range((page - 1) * pageSize, page * pageSize);
-    if (error) {
-        throw new Error(`Error fetching categories: ${error.message}`);
+        const { data, error, count } = await supabase.rpc('get_all_categories', {
+            _name_filter: filters.name ?? null,
+        }, { count: 'exact' }).range(start, end);
+        if (error) {
+            console.error('Error fetching categories:', error.message);
+            return { data: [], count: 0 };
+        }
+        return { data: data ?? [], count: count ?? 0 };
+    } catch (error: any) {
+        console.error('Error fetching categories:', error.message);
+        return { data: [], count: 0 };
     }
-    return { data, count };
 }
 
 export const addCategory = async (name: string, image: string | null, ar_name: string) => await fetchDataById('add_category', { _name: name, _image: image ?? null, _ar_name: ar_name });

--- a/src/action/lms-admin/categories/categoriesActions.ts
+++ b/src/action/lms-admin/categories/categoriesActions.ts
@@ -2,12 +2,13 @@
 
 import { createClient } from "@/utils/supabase/server";
 
-export const getCategoriesOptions = async (organization_id: number) => {
+export const getCategoriesOptions = async () => {
   const supabase = await createClient();
-  // const { data, error } = await supabase.rpc('get_categories_options');
-  const { data, error } = await supabase.from('categories').select('id, name').eq('organization_id', organization_id).order('name', { ascending: true });
+  const { data, error } = await supabase.rpc('get_categories');
   if (error) {
-    throw new Error(`Error fetching categories options: ${error.message}`);
+    console.error('Error fetching categories options:', error.message);
+    return [];
   }
-  return data;
+  // Map to { id, name } shape expected by the filter component
+  return (data ?? []).map((c: { id: number; name: string }) => ({ id: c.id, name: c.name }));
 }

--- a/src/action/lms-admin/insights/courses/coursesAction.ts
+++ b/src/action/lms-admin/insights/courses/coursesAction.ts
@@ -30,26 +30,23 @@ export const fetchCoursesByCategory = () => fetchData('get_courses_by_category')
 export const coursesTitlesAndIds = () => fetchData('get_course_titles_and_ids');
 
 export const fetchAllCourses = async (page: number, pageSize: number, filters: any) => {
-    const supabase = await createClient();
-    let loading = true;
-    let errorMessage = '';
-    const start = (page - 1) * pageSize;
-    const end = start + pageSize - 1;
     try {
+        const supabase = await createClient();
+        const start = (page - 1) * pageSize;
+        const end = start + pageSize - 1;
         const { data, error, count } = await supabase.rpc('get_all_courses', {
             _name_filter: filters.name ?? null,
             _category_filter: filters.category ?? null,
             _status_filter: filters.status ?? null,
         }, { count: 'exact' }).range(start, end)
         if (error) {
-            throw new Error(`Error fetching get_all_courses: ${error.message}`);
+            console.error('Error fetching get_all_courses:', error.message);
+            return { data: [], count: 0 };
         }
-        return { data, count };
+        return { data: data ?? [], count: count ?? 0 };
     } catch (error: any) {
-        errorMessage = error.message;
-        console.error(errorMessage);
-    } finally {
-        loading = false;
+        console.error('Error fetching get_all_courses:', error.message);
+        return { data: [], count: 0 };
     }
 }
 
@@ -75,15 +72,20 @@ export const fetchCourseStatusCounts = async () => {
 };
 
 export const exportCourses = async () => {
-    const supabase = await createClient();
-    const { data, error } = await supabase.rpc('get_all_courses', {
-        _name_filter: null,
-        _category_filter: null,
-        _status_filter: null,
-    });
-
-    if (error) {
-        throw new Error(`Error exporting courses: ${error.message}`);
+    try {
+        const supabase = await createClient();
+        const { data, error } = await supabase.rpc('get_all_courses', {
+            _name_filter: null,
+            _category_filter: null,
+            _status_filter: null,
+        });
+        if (error) {
+            console.error('Error exporting courses:', error.message);
+            return [];
+        }
+        return data ?? [];
+    } catch (error: any) {
+        console.error('Error exporting courses:', error.message);
+        return [];
     }
-    return data;
 }

--- a/src/app/dashboard/@lms_admin/(courses_categorise)/categories/@table/page.tsx
+++ b/src/app/dashboard/@lms_admin/(courses_categorise)/categories/@table/page.tsx
@@ -16,17 +16,14 @@ export default async function CategoryDataTablePage({ searchParams, userRole }: 
     name: searchParams.name ?? null,
   };
   
-  const  {data ,count}  = await fetchAllCategoriesFiltered(filters, page, pageSize);
-  if (data) {
-    return (
-      <CategoryTable
-        AllCategories={data}
-        page={page}
-        pageSize={pageSize}
-        filters={filters}
-        count={count ?? 0}
-      />
-    );
-  }
-  return null;
+  const { data, count } = await fetchAllCategoriesFiltered(filters, page, pageSize);
+  return (
+    <CategoryTable
+      AllCategories={data}
+      page={page}
+      pageSize={pageSize}
+      filters={filters}
+      count={count ?? 0}
+    />
+  );
 }

--- a/src/app/dashboard/@lms_admin/(courses_categorise)/courses/@table/page.tsx
+++ b/src/app/dashboard/@lms_admin/(courses_categorise)/courses/@table/page.tsx
@@ -18,18 +18,14 @@ export default async function CoursesDataTablePage({ searchParams ,userRole}: { 
     status: searchParams.status ?? null,
   };
 
-  const result = await fetchAllCourses(page, pageSize, filters);
-  if (result) {
-    const { data, count } = result;
-    return (
-      <CourseTable
-        courses={data}
-        count={count ?? 0}
-        currentPage={page}
-        pageSize={pageSize}
-        userRole={userRole}
-      />
-    );
-  }
-  return null;
+  const { data, count } = await fetchAllCourses(page, pageSize, filters);
+  return (
+    <CourseTable
+      courses={data}
+      count={count ?? 0}
+      currentPage={page}
+      pageSize={pageSize}
+      userRole={userRole}
+    />
+  );
 }

--- a/src/app/dashboard/@lms_admin/(courses_categorise)/courses/table/course-table/CoursesFilter.tsx
+++ b/src/app/dashboard/@lms_admin/(courses_categorise)/courses/table/course-table/CoursesFilter.tsx
@@ -9,7 +9,6 @@ import { debounce } from '@/utils/debounce';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { getCategoriesOptions } from '@/action/lms-admin/categories/categoriesActions';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useAppSelector } from '@/hooks/redux.hook';
 import { CourseStatusBadge } from '@/components/shared/StatusBadge';
 
 const STATUS_OPTIONS = [
@@ -20,7 +19,6 @@ const STATUS_OPTIONS = [
 ];
 
 function CoursesFilter() {
-    const { settings } = useAppSelector(state => state.organization);
     const [isFilterOpen, setIsFilterOpen] = useState(false);
     const [categoryOptions, setCategoryOptions] = useState<{ id: string, name: string }[]>([]);
     const [isLoading, setIsLoading] = useState(false);
@@ -31,11 +29,12 @@ function CoursesFilter() {
         async function fetchCategoryOptions() {
             setIsLoading(true);
             try {
-                const data = await getCategoriesOptions(+settings.organization_id);
+                const data = await getCategoriesOptions();
                 setCategoryOptions(data);
-                setIsLoading(false);
             } catch (error) {
                 console.error('Failed to fetch category options:', error);
+            } finally {
+                setIsLoading(false);
             }
         }
         fetchCategoryOptions();

--- a/src/app/dashboard/@lms_admin/insights/courses/CoursesFilter.tsx
+++ b/src/app/dashboard/@lms_admin/insights/courses/CoursesFilter.tsx
@@ -9,12 +9,10 @@ import { debounce } from '@/utils/debounce';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { getCategoriesOptions } from '@/action/lms-admin/categories/categoriesActions';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useAppSelector } from '@/hooks/redux.hook';
 
 
 function CoursesFilter() {
     const [isFilterOpen, setIsFilterOpen] = useState(false);
-    const { settings } = useAppSelector(state => state.organization);
     const [categoryOptions, setCategoryOptions] = useState<{ id: string, name: string}[]>([]);
     const [isLoading, setIsLoading] = useState(false);
     const searchParams = useSearchParams();
@@ -24,15 +22,16 @@ function CoursesFilter() {
         async function fetchCategoryOptions() {
             setIsLoading(true);
             try {
-                const data = await getCategoriesOptions(+settings.organization_id);
+                const data = await getCategoriesOptions();
                 setCategoryOptions(data);
-                setIsLoading(false);
             } catch (error) {
                 console.error('Failed to fetch category options:', error);
+            } finally {
+                setIsLoading(false);
             }
         }
         fetchCategoryOptions();
-    }, [settings.organization_id]);
+    }, []);
 
     const handleDebouncedFilterChange = debounce((columnId: string, value: string | null) => {
         const params = new URLSearchParams(searchParams.toString());


### PR DESCRIPTION
…fetch

Root causes:
1. getCategoriesOptions used direct table query with client-provided org_id that defaulted to 0 on initial render (Redux not loaded yet). Switched to get_categories RPC which uses auth.uid() server-side — no client param needed.

2. fetchAllCategoriesFiltered threw on RPC error with no try-catch in the server component, causing unhandled exception → 500. Wrapped in try-catch returning { data: [], count: 0 } on failure.

3. fetchAllCourses had createClient() outside try-catch — any cookie/auth issue would throw unhandled. Moved inside try-catch, always returns { data, count } (never undefined).

4. Both CoursesFilter components (courses page + insights page) removed dependency on Redux organization_id since the RPC handles org scoping.

5. Fixed range calculation in fetchAllCategoriesFiltered (was off-by-one).

https://claude.ai/code/session_01SC1b8MQuxedfJebyopteX2