### PR TITLE
Move certificate settings from org admin to LMS admin sidebar

### DIFF
--- a/src/app/dashboard/@lms_admin/certificate-settings/page.tsx
+++ b/src/app/dashboard/@lms_admin/certificate-settings/page.tsx
@@ -1,0 +1,14 @@
+import dynamic from "next/dynamic";
+
+const CertificateSettings = dynamic(
+  () => import("@/components/app/organizationSettings/certificates"),
+  { ssr: false }
+);
+
+export default function CertificateSettingsPage() {
+  return (
+    <div className="w-full h-full p-4 sm:p-6">
+      <CertificateSettings />
+    </div>
+  );
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -118,6 +118,12 @@ const lmsAdminNav: NavGroup[] = [
     ],
   },
   {
+    label: "Management",
+    items: [
+      { name: "Certificate Settings", href: "/dashboard/certificate-settings", icon: Medal },
+    ],
+  },
+  {
     label: "AI",
     items: [{ name: "AI Config", href: "/dashboard/ai-config", icon: Bot }],
   },

--- a/src/components/app/organizationSettings/index.tsx
+++ b/src/components/app/organizationSettings/index.tsx
@@ -9,7 +9,6 @@ const Registeration = dynamic(() => import("./registeration"), { ssr: false });
 const Courses = dynamic(() => import("./courses"), { ssr: false });
 const Subscription = dynamic(() => import("./subscription"), { ssr: false });
 const Branding = dynamic(() => import("./branding"), { ssr: false });
-const Certificates = dynamic(() => import("./certificates"), { ssr: false });
 const UsedSkelton = dynamic(() => import("./skeletons/used-skelton"), { ssr: false });
 const SubscriptionSkelton = dynamic(() => import("./skeletons/SubscriptionSkelton"), { ssr: false });
 
@@ -42,9 +41,6 @@ export default function Settings() {
         </div>
         <div x-chunk="dashboard-01-chunk-2" className="w-full md:h-full h-fit lg:col-span-1 col-span-2">
           <Branding />
-        </div>
-        <div x-chunk="dashboard-01-chunk-2" className="w-full xl:h-full h-fit lg:col-span-1 col-span-2">
-          <Certificates />
         </div>
       </div>
     </div>

--- a/src/utils/constants/navigationItems.tsx
+++ b/src/utils/constants/navigationItems.tsx
@@ -82,6 +82,10 @@ const lmsAdminRoutes = [
     name: "AI Config",
     href: "/dashboard/ai-config",
   },
+  {
+    name: "Certificate Settings",
+    href: "/dashboard/certificate-settings",
+  },
 ];
 
 const learningManagerRoutes = [


### PR DESCRIPTION
Certificate template management is now accessed via a dedicated "Certificate Settings" link in the LMS admin sidebar under a new "Management" group, instead of being embedded in the org admin organization settings page.

https://claude.ai/code/session_01Q26E98tuZmYjU7RVBbw8aN