### PR TITLE
Fix migration: drop functions before re-creating with new return types

### DIFF
--- a/supabase/migrations/20260225000000_certificate_phase1.sql
+++ b/supabase/migrations/20260225000000_certificate_phase1.sql
@@ -53,6 +53,7 @@ ALTER TABLE public.organization_settings
   ADD COLUMN IF NOT EXISTS linkedin_company_id TEXT;
 
 -- ==========  6. Updated RPC: insert_user_certificate (now returns uuid)  ==========
+DROP FUNCTION IF EXISTS public.insert_user_certificate(text, int);
 CREATE OR REPLACE FUNCTION public.insert_user_certificate(
   certificate_url text,
   course int,
@@ -230,6 +231,7 @@ END;
 $$;
 
 -- ==========  12. Updated RPC: get_certificate_if_exists (now includes uuid)  ==========
+DROP FUNCTION IF EXISTS public.get_certificate_if_exists(int);
 CREATE OR REPLACE FUNCTION public.get_certificate_if_exists(course_id int)
 RETURNS TABLE (
   certificate text,
@@ -248,6 +250,7 @@ AS $$
 $$;
 
 -- ==========  13. Updated RPC: get_user_certificates (now includes uuid + status)  ==========
+DROP FUNCTION IF EXISTS public.get_user_certificates();
 CREATE OR REPLACE FUNCTION public.get_user_certificates()
 RETURNS TABLE (
   id          int,


### PR DESCRIPTION
PostgreSQL cannot change the return type of an existing function via CREATE OR REPLACE. Add DROP FUNCTION IF EXISTS before re-creating insert_user_certificate, get_certificate_if_exists, and get_user_certificates with their updated signatures.

https://claude.ai/code/session_01Q26E98tuZmYjU7RVBbw8aN