### PR TITLE
Fix update_organization_branding RPC: drop old overload, make all par…

### DIFF
--- a/supabase/migrations/20260222130000_branding_colors.sql
+++ b/supabase/migrations/20260222130000_branding_colors.sql
@@ -1,11 +1,18 @@
 -- Add primary_color and secondary_color to update_organization_branding RPC
 -- so org admins can control their tenant colors from the branding settings UI.
+--
+-- The original function had signature (new_logo text, new_auth text, new_name text, orgid int).
+-- Adding params with defaults would create an overload rather than replacing it,
+-- so we must drop the old version first.
+
+DROP FUNCTION IF EXISTS public.update_organization_branding(text, text, text, int);
+DROP FUNCTION IF EXISTS public.update_organization_branding(text, text, text, int, text, text);
 
 CREATE OR REPLACE FUNCTION public.update_organization_branding(
-  new_logo text,
-  new_auth text,
-  new_name text,
   orgid int,
+  new_logo text DEFAULT NULL,
+  new_auth text DEFAULT NULL,
+  new_name text DEFAULT NULL,
   new_primary_color text DEFAULT NULL,
   new_secondary_color text DEFAULT NULL
 )


### PR DESCRIPTION
…ams optional

The original function had signature (new_logo, new_auth, new_name, orgid) with all required params. The migration that added color params created a second overloaded function instead of replacing the original, and new_logo/new_auth/new_name were still required — so PostgREST returned 404 when the frontend only sent {new_primary_color, new_secondary_color, orgid}.

Fix: drop both old overloads, recreate with orgid as the only required param and all others DEFAULT NULL so any subset of fields can be updated.

https://claude.ai/code/session_01Q26E98tuZmYjU7RVBbw8aN