### PR TITLE
fix: handle null courseId in course creation redirect and build-cours…

### DIFF
--- a/src/app/dashboard/@lms_admin/(courses_categorise)/courses/add-course/CourseDetails.tsx
+++ b/src/app/dashboard/@lms_admin/(courses_categorise)/courses/add-course/CourseDetails.tsx
@@ -132,6 +132,11 @@ export default function CourseDetails({ categories, features }: { categories: Co
             toast.error("Error", {
                description: errorMessage,
             });
+         } else if (!courseData) {
+            setIsLoading(false);
+            toast.error("Error", {
+               description: "Failed to create course. Please try again.",
+            });
          } else {
             setIsLoading(false);
 

--- a/src/app/dashboard/@lms_admin/(courses_categorise)/courses/add-course/build-course/page.tsx
+++ b/src/app/dashboard/@lms_admin/(courses_categorise)/courses/add-course/build-course/page.tsx
@@ -14,7 +14,8 @@ import { AICourseWizard } from '@/components/authoring/ai/AICourseWizard';
 export default function BuildCoursePage() {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const courseId = searchParams.get('courseId');
+  const rawCourseId = searchParams.get('courseId');
+  const courseId = rawCourseId && rawCourseId !== 'null' && !isNaN(Number(rawCourseId)) ? rawCourseId : null;
   const mode = searchParams.get('mode'); // 'ai' for AI wizard
   const [courseTitle, setCourseTitle] = useState('');
   const [loading, setLoading] = useState(true);
@@ -38,6 +39,11 @@ export default function BuildCoursePage() {
       }
 
       const course = Array.isArray(data) ? data[0] : data;
+      if (!course) {
+        setError('Course not found');
+        setLoading(false);
+        return;
+      }
       setCourseTitle(course.title || '');
 
       // Initialize editor store with course content


### PR DESCRIPTION
…e page

When add_course RPC returns null data, the redirect created a URL with courseId=null (literal string), causing build-course page to crash with "Cannot read properties of undefined (reading 'title')". Now validates courseData before redirect and sanitizes courseId param on build-course page.

https://claude.ai/code/session_01R5WhtkpDFAraV5jCFAPRoU