### PR TITLE
fix: ensure delete_course_and_related_user_courses RPC function exists

### DIFF
--- a/supabase/migrations/20260301000003_fix_delete_course_function.sql
+++ b/supabase/migrations/20260301000003_fix_delete_course_function.sql
@@ -1,0 +1,14 @@
+-- Fix: Ensure delete_course_and_related_user_courses function exists
+-- The baseline migration defined it but it may not have been created in the database
+
+CREATE OR REPLACE FUNCTION public.delete_course_and_related_user_courses(p_course_id int)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+  DELETE FROM user_certificates WHERE course_id = p_course_id;
+  DELETE FROM user_courses      WHERE course_id = p_course_id;
+  DELETE FROM certificates      WHERE course   = p_course_id;
+  DELETE FROM courses           WHERE id       = p_course_id;
+END;
+$$;


### PR DESCRIPTION
The function was defined in the baseline migration but was not found in the database schema cache, causing "Failed to delete course" errors.

This migration recreates the function to ensure it exists.

https://claude.ai/code/session_01R5WhtkpDFAraV5jCFAPRoU