### PR TITLE
fix: use SECURITY DEFINER RPC for AI/Document Builder feature flags

### DIFF
--- a/src/action/organization/organizationAction.ts
+++ b/src/action/organization/organizationAction.ts
@@ -60,22 +60,19 @@ export async function get_organization_statistics() {
 export async function getAiAndDocumentBuilder(organization_id: number) {
   try {
     const supabase = await createClient();
-    const { data, error } = await supabase
-      .from('organization_settings')
-      .select('ai_builder, document_builder , create_courses')
-      .eq('organization_id', organization_id)
-      .single();
+    const { data, error } = await supabase.rpc('get_org_feature_flags', {
+      p_org_id: organization_id,
+    });
 
-    if (error) {
-      // silently handled
+    if (error || !data || data.length === 0) {
+      return { ai_builder: false, document_builder: false, create_courses: true };
     }
-    // Default create_courses to true so existing orgs aren't blocked
-    // when the column is missing or null in organization_settings
+
+    const row = data[0];
     return {
-      ai_builder: false,
-      document_builder: false,
-      create_courses: true,
-      ...data,
+      ai_builder: row.ai_builder ?? false,
+      document_builder: row.document_builder ?? false,
+      create_courses: row.create_courses ?? true,
     };
   } catch {
     return { ai_builder: false, document_builder: false, create_courses: true };

--- a/supabase/migrations/20260301000005_enable_ai_and_document_builder.sql
+++ b/supabase/migrations/20260301000005_enable_ai_and_document_builder.sql
@@ -10,3 +10,19 @@ SET ai_builder       = true,
 UPDATE public.organization_settings
 SET ai_builder       = true,
     document_builder = true;
+
+-- Create a SECURITY DEFINER RPC to fetch org feature flags.
+-- The previous code queried organization_settings directly with the anon key,
+-- which can fail silently under RLS even for authenticated users.
+CREATE OR REPLACE FUNCTION public.get_org_feature_flags(p_org_id int)
+RETURNS TABLE (
+  ai_builder       boolean,
+  document_builder boolean,
+  create_courses   boolean
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT os.ai_builder, os.document_builder, os.create_courses
+  FROM organization_settings os
+  WHERE os.organization_id = p_org_id;
+$$;


### PR DESCRIPTION
The getAiAndDocumentBuilder function was querying organization_settings directly with the anon key. Since RLS is enabled on that table, the query could fail silently, returning default values (false) which locked users out of AI and Document course creation.

Changes:
- Add get_org_feature_flags RPC with SECURITY DEFINER to bypass RLS
- Update getAiAndDocumentBuilder to call the new RPC instead of direct query
- Enable ai_builder and document_builder for all existing orgs and tiers

https://claude.ai/code/session_01R5WhtkpDFAraV5jCFAPRoU