### PR TITLE
fix: resolve pdf.worker.js crash in serverless and add PPTX support

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,11 @@ import { withSentryConfig } from '@sentry/nextjs';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+    experimental: {
+        // Keep pdfjs-dist as a Node.js external so its internal worker file
+        // (pdf.worker.js) resolves correctly in Vercel serverless functions.
+        serverComponentsExternalPackages: ['pdfjs-dist'],
+    },
     webpack: (config) => {
         // pdfjs-dist optionally requires 'canvas' (native module) for Node.js rendering.
         // We only use it for text extraction, so mark it as external to avoid build errors.

--- a/src/app/api/ai/extract-document/route.ts
+++ b/src/app/api/ai/extract-document/route.ts
@@ -30,11 +30,13 @@ export async function POST(req: NextRequest) {
       'application/pdf',
       'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       'application/msword',
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      'application/vnd.ms-powerpoint',
     ];
 
     if (!allowedTypes.includes(file.type)) {
       return NextResponse.json(
-        { error: 'Only PDF and DOCX files are supported' },
+        { error: 'Only PDF, DOCX, and PPTX files are supported' },
         { status: 400 }
       );
     }

--- a/src/components/authoring/ai/DocumentUploader.tsx
+++ b/src/components/authoring/ai/DocumentUploader.tsx
@@ -33,10 +33,12 @@ export function DocumentUploader({ onExtracted }: DocumentUploaderProps) {
         'application/pdf',
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         'application/msword',
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        'application/vnd.ms-powerpoint',
       ];
 
       if (!allowedTypes.includes(selectedFile.type)) {
-        toast.error('Only PDF and DOCX files are supported');
+        toast.error('Only PDF, DOCX, and PPTX files are supported');
         return;
       }
 
@@ -181,7 +183,7 @@ export function DocumentUploader({ onExtracted }: DocumentUploaderProps) {
       <input
         id="doc-upload-input"
         type="file"
-        accept=".pdf,.docx,.doc"
+        accept=".pdf,.docx,.doc,.pptx,.ppt"
         className="hidden"
         onChange={handleInputChange}
       />
@@ -191,7 +193,7 @@ export function DocumentUploader({ onExtracted }: DocumentUploaderProps) {
           <Upload className="h-8 w-8 text-muted-foreground" />
         </div>
         <p className="text-sm font-medium">
-          Drop a PDF or DOCX file here
+          Drop a PDF, DOCX, or PPTX file here
         </p>
         <p className="text-xs text-muted-foreground">
           The AI will use this document as source material for the course

--- a/src/lib/ai/document-processor.ts
+++ b/src/lib/ai/document-processor.ts
@@ -1,4 +1,4 @@
-// src/lib/ai/document-processor.ts -- Phase 3: PDF/DOCX text extraction
+// src/lib/ai/document-processor.ts -- Phase 3: PDF/DOCX/PPTX text extraction
 
 import type { DocumentChunk } from '@/types/authoring';
 
@@ -7,7 +7,7 @@ export class DocumentProcessor {
    * Extract text from PDF using pdfjs-dist.
    */
   async extractPdf(buffer: ArrayBuffer): Promise<DocumentChunk[]> {
-    const pdfjsLib = await import('pdfjs-dist');
+    const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.js');
     const chunks: DocumentChunk[] = [];
 
     const pdf = await pdfjsLib.getDocument({ data: buffer }).promise;
@@ -115,6 +115,47 @@ export class DocumentProcessor {
   }
 
   /**
+   * Extract text from PPTX using JSZip (PPTX is a ZIP of XML files).
+   */
+  async extractPptx(buffer: ArrayBuffer): Promise<DocumentChunk[]> {
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(buffer);
+    const chunks: DocumentChunk[] = [];
+
+    // Collect slide file names and sort numerically (slide1.xml, slide2.xml, ...)
+    const slideFiles = Object.keys(zip.files)
+      .filter((name) => /^ppt\/slides\/slide\d+\.xml$/.test(name))
+      .sort((a, b) => {
+        const numA = parseInt(a.match(/slide(\d+)/)?.[1] || '0');
+        const numB = parseInt(b.match(/slide(\d+)/)?.[1] || '0');
+        return numA - numB;
+      });
+
+    for (let i = 0; i < slideFiles.length; i++) {
+      const xml = await zip.files[slideFiles[i]].async('string');
+      // Extract text from <a:t> tags (PowerPoint text runs)
+      const textParts: string[] = [];
+      const regex = /<a:t>([\s\S]*?)<\/a:t>/g;
+      let match;
+      while ((match = regex.exec(xml)) !== null) {
+        const text = match[1].trim();
+        if (text) textParts.push(text);
+      }
+
+      const slideText = textParts.join(' ').trim();
+      if (slideText) {
+        chunks.push({
+          text: slideText,
+          page_number: i + 1,
+          type: 'text',
+        });
+      }
+    }
+
+    return chunks;
+  }
+
+  /**
    * Auto-detect file type and extract chunks.
    */
   async extract(
@@ -128,6 +169,9 @@ export class DocumentProcessor {
       case 'docx':
       case 'doc':
         return this.extractDocx(buffer);
+      case 'pptx':
+      case 'ppt':
+        return this.extractPptx(buffer);
       default:
         throw new Error(`Unsupported file type: ${ext}`);
     }


### PR DESCRIPTION
- Add pdfjs-dist to serverComponentsExternalPackages so the internal pdf.worker.js resolves correctly in Vercel serverless functions (fixes "Cannot find module '/pdf.worker.js'" error)
- Use pdfjs-dist legacy build for better Node.js compatibility
- Add PPTX/PPT file extraction using JSZip (parse slide XML)
- Update API route, DocumentUploader, and DocumentProcessor to accept PowerPoint files alongside PDF and DOCX

https://claude.ai/code/session_01R5WhtkpDFAraV5jCFAPRoU