### PR TITLE
feat: redesign AI Course Wizard from 3-step to 6-step pipeline

### DIFF
--- a/src/app/api/ai/generate-course-details/route.ts
+++ b/src/app/api/ai/generate-course-details/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server';
+import { getPlatformAIModel, logUsage, GatewayError } from '@/lib/ai/gateway';
+import { generateText } from 'ai';
+import { COURSE_DETAILS_SYSTEM_PROMPT, COURSE_DETAILS_USER_PROMPT } from '@/lib/ai/prompts';
+import { z } from 'zod';
+import type { CourseDetails } from '@/types/authoring';
+
+export const maxDuration = 60;
+
+const requestSchema = z.object({
+  description: z.string().min(3).max(2000),
+  language: z.enum(['ar', 'en']),
+  source_chunks: z.string().optional(),
+  industry: z.string().optional(),
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const parsed = requestSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid request', details: parsed.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    const params = parsed.data;
+
+    let platform;
+    try {
+      platform = getPlatformAIModel();
+    } catch (err) {
+      if (err instanceof GatewayError) {
+        return NextResponse.json({ error: err.message }, { status: err.status });
+      }
+      throw err;
+    }
+
+    const startTime = Date.now();
+
+    const result = await generateText({
+      model: platform.model,
+      system: COURSE_DETAILS_SYSTEM_PROMPT,
+      prompt: COURSE_DETAILS_USER_PROMPT({
+        description: params.description,
+        language: params.language,
+        sourceChunks: params.source_chunks,
+        industry: params.industry,
+      }),
+      temperature: 0.7,
+      maxOutputTokens: 2000,
+    });
+
+    const durationMs = Date.now() - startTime;
+
+    let details: CourseDetails;
+    try {
+      let text = result.text.trim();
+      if (text.startsWith('```json')) text = text.slice(7);
+      if (text.startsWith('```')) text = text.slice(3);
+      if (text.endsWith('```')) text = text.slice(0, -3);
+      details = JSON.parse(text.trim());
+    } catch {
+      return NextResponse.json(
+        { error: 'AI returned invalid JSON. Please try again.' },
+        { status: 502 }
+      );
+    }
+
+    const inputTokens = result.usage?.inputTokens || 0;
+    const outputTokens = result.usage?.outputTokens || 0;
+
+    await supabase.from('ai_generation_log').insert({
+      organization_id: (await supabase.rpc('get_user_org_id')).data,
+      user_id: user.id,
+      operation: 'generate_course_details',
+      model: platform.modelId,
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      cost_usd: estimateCost(inputTokens, outputTokens, platform.modelId),
+      input_summary: `Description: ${params.description.slice(0, 100)}`,
+      output_summary: `Topic: ${details.topic?.slice(0, 80) || 'N/A'}`,
+      duration_ms: durationMs,
+    });
+
+    await logUsage(supabase, 'generate_course_details', inputTokens + outputTokens);
+
+    return NextResponse.json({ details });
+  } catch (error) {
+    console.error('Course details generation error:', error);
+    return NextResponse.json(
+      { error: 'Failed to generate course details' },
+      { status: 500 }
+    );
+  }
+}
+
+function estimateCost(inputTokens: number, outputTokens: number, model: string): number {
+  if (model.includes('sonnet')) {
+    return (inputTokens * 3 + outputTokens * 15) / 1_000_000;
+  }
+  if (model.includes('haiku')) {
+    return (inputTokens * 0.8 + outputTokens * 4) / 1_000_000;
+  }
+  return (inputTokens * 3 + outputTokens * 15) / 1_000_000;
+}

--- a/src/components/authoring/ai/AICourseWizard.tsx
+++ b/src/components/authoring/ai/AICourseWizard.tsx
@@ -1,24 +1,27 @@
 'use client';
 
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Loader2, Sparkles, ArrowLeft, ArrowRight, Check } from 'lucide-react';
+import { Check } from 'lucide-react';
 import { toast } from 'sonner';
-import type { CourseOutline, DocumentChunk } from '@/types/authoring';
-import { OutlineEditor } from './OutlineEditor';
-import { GenerationProgress } from './GenerationProgress';
-import { DocumentUploader } from './DocumentUploader';
+import type {
+  ContentOptions,
+  CourseDetails,
+  CourseOutline,
+  DocumentChunk,
+  CourseLength,
+} from '@/types/authoring';
+import { COURSE_LENGTH_CONFIG } from '@/types/authoring';
+import { StepSourceMaterial, type SourceMaterialData } from './StepSourceMaterial';
+import { StepCourseDetails } from './StepCourseDetails';
+import { StepLearningObjectives } from './StepLearningObjectives';
+import { StepOutlineEditor } from './StepOutlineEditor';
+import { StepContentOptions } from './StepContentOptions';
+import { StepGeneration } from './StepGeneration';
+import { cn } from '@/lib/utils';
+
+// ============================================================
+// TYPES
+// ============================================================
 
 interface AICourseWizardProps {
   courseId: number;
@@ -26,57 +29,152 @@ interface AICourseWizardProps {
   onCancel: () => void;
 }
 
-type WizardStep = 'settings' | 'outline' | 'generate';
+type WizardStep =
+  | 'source'
+  | 'details'
+  | 'objectives'
+  | 'outline'
+  | 'options'
+  | 'generate';
+
+const STEPS: { key: WizardStep; label: string; shortLabel: string }[] = [
+  { key: 'source', label: 'Source material', shortLabel: 'Source' },
+  { key: 'details', label: 'Course details', shortLabel: 'Details' },
+  { key: 'objectives', label: 'Learning objectives', shortLabel: 'Objectives' },
+  { key: 'outline', label: 'Course outline', shortLabel: 'Outline' },
+  { key: 'options', label: 'Content options', shortLabel: 'Options' },
+  { key: 'generate', label: 'Generate', shortLabel: 'Generate' },
+];
+
+// ============================================================
+// WIZARD COMPONENT
+// ============================================================
 
 export function AICourseWizard({
   courseId,
   onComplete,
   onCancel,
 }: AICourseWizardProps) {
-  const [step, setStep] = useState<WizardStep>('settings');
+  // Current step
+  const [step, setStep] = useState<WizardStep>('source');
+
+  // Loading states
+  const [isGeneratingDetails, setIsGeneratingDetails] = useState(false);
   const [isGeneratingOutline, setIsGeneratingOutline] = useState(false);
 
-  // Settings state
-  const [topic, setTopic] = useState('');
-  const [audience, setAudience] = useState('');
-  const [difficulty, setDifficulty] = useState<
-    'beginner' | 'intermediate' | 'advanced'
-  >('intermediate');
-  const [language, setLanguage] = useState<'ar' | 'en'>('ar');
-  const [tone, setTone] = useState<'formal' | 'conversational' | 'academic'>(
-    'formal'
-  );
-  const [moduleCount, setModuleCount] = useState(4);
-  const [lessonsPerModule, setLessonsPerModule] = useState(3);
-  const [sourceChunks, setSourceChunks] = useState<DocumentChunk[]>([]);
+  // Step 1: Source material data
+  const [sourceData, setSourceData] = useState<SourceMaterialData>({
+    description: '',
+    sourceChunks: [],
+    language: 'ar',
+    industry: 'general',
+  });
 
-  // Outline state
+  // Step 2: Course details (AI-generated, user-editable)
+  const [courseDetails, setCourseDetails] = useState<CourseDetails>({
+    topic: '',
+    tone: '',
+    audience: '',
+    goals: '',
+    difficulty: 'intermediate',
+    suggested_length: 'short',
+    learning_objectives: [],
+  });
+
+  // Step 3: Learning objectives (editable copy from courseDetails)
+  const [objectives, setObjectives] = useState<string[]>([]);
+
+  // Step 4: Course outline (AI-generated, user-editable)
   const [outline, setOutline] = useState<CourseOutline | null>(null);
 
-  const handleGenerateOutline = async () => {
-    if (!topic.trim() || !audience.trim()) {
-      toast.error('Please fill in topic and audience');
-      return;
-    }
+  // Step 5: Content options
+  const [contentOptions, setContentOptions] = useState<ContentOptions>({
+    content_format: 'interactive',
+    generate_images: true,
+    assessment_density: 'per_lesson',
+  });
 
-    setIsGeneratingOutline(true);
+  // --------------------------------------------------------
+  // Step transitions
+  // --------------------------------------------------------
+
+  /** Step 1 → Step 2: Generate course details from description */
+  const handleSourceNext = async () => {
+    setIsGeneratingDetails(true);
     try {
       const contextText =
-        sourceChunks.length > 0
-          ? sourceChunks.map((c) => c.text).join('\n\n').slice(0, 15000)
+        sourceData.sourceChunks.length > 0
+          ? sourceData.sourceChunks
+              .map((c) => c.text)
+              .join('\n\n')
+              .slice(0, 15000)
+          : undefined;
+
+      const res = await fetch('/api/ai/generate-course-details', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          description: sourceData.description,
+          language: sourceData.language,
+          source_chunks: contextText,
+          industry:
+            sourceData.industry !== 'general'
+              ? sourceData.industry
+              : undefined,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Failed to generate course details');
+      }
+
+      const data = await res.json();
+      const details: CourseDetails = data.details;
+
+      setCourseDetails(details);
+      setObjectives(details.learning_objectives || []);
+      setStep('details');
+    } catch (error) {
+      toast.error('Course details generation failed', {
+        description:
+          error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setIsGeneratingDetails(false);
+    }
+  };
+
+  /** Step 3 → Step 4: Generate outline from details + objectives */
+  const handleObjectivesNext = async () => {
+    setIsGeneratingOutline(true);
+    try {
+      const lengthConfig =
+        COURSE_LENGTH_CONFIG[courseDetails.suggested_length];
+
+      const contextText =
+        sourceData.sourceChunks.length > 0
+          ? sourceData.sourceChunks
+              .map((c) => c.text)
+              .join('\n\n')
+              .slice(0, 15000)
           : undefined;
 
       const res = await fetch('/api/ai/generate-outline', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          topic,
-          audience,
-          difficulty,
-          language,
-          tone,
-          module_count: moduleCount,
-          lessons_per_module: lessonsPerModule,
+          topic: courseDetails.topic,
+          audience: courseDetails.audience,
+          difficulty: courseDetails.difficulty,
+          language: sourceData.language,
+          tone: courseDetails.tone.includes('formal')
+            ? 'formal'
+            : courseDetails.tone.includes('academic')
+              ? 'academic'
+              : 'conversational',
+          module_count: lengthConfig.modules,
+          lessons_per_module: lengthConfig.lessonsPerModule,
           source_chunks: contextText,
         }),
       });
@@ -87,7 +185,19 @@ export function AICourseWizard({
       }
 
       const data = await res.json();
-      setOutline(data.outline);
+      const generatedOutline: CourseOutline = data.outline;
+
+      // Inject the edited learning objectives
+      generatedOutline.learning_outcomes = objectives;
+
+      // Ensure every lesson has a topics array
+      generatedOutline.modules.forEach((mod) => {
+        mod.lessons.forEach((les) => {
+          if (!les.topics) les.topics = [];
+        });
+      });
+
+      setOutline(generatedOutline);
       setStep('outline');
     } catch (error) {
       toast.error('Outline generation failed', {
@@ -99,262 +209,123 @@ export function AICourseWizard({
     }
   };
 
-  const handleDocumentExtracted = (chunks: DocumentChunk[]) => {
-    setSourceChunks(chunks);
-    if (!topic.trim() && chunks.length > 0) {
-      // Auto-fill topic from first heading
-      const firstHeading = chunks.find((c) => c.type === 'heading');
-      if (firstHeading) {
-        setTopic(firstHeading.text);
-      }
-    }
-  };
-
-  const handleOutlineApproved = (editedOutline: CourseOutline) => {
-    setOutline(editedOutline);
-    setStep('generate');
-  };
+  // --------------------------------------------------------
+  // Step index helper
+  // --------------------------------------------------------
+  const currentStepIndex = STEPS.findIndex((s) => s.key === step);
 
   return (
-    <div className="max-w-4xl mx-auto space-y-6">
-      {/* Step indicator */}
-      <div className="flex items-center gap-2 text-sm">
-        {(['settings', 'outline', 'generate'] as WizardStep[]).map(
-          (s, i) => (
-            <div key={s} className="flex items-center gap-2">
+    <div className="max-w-5xl mx-auto space-y-6">
+      {/* ──────────────────────────────────────────────────── */}
+      {/* STEP INDICATOR                                      */}
+      {/* ──────────────────────────────────────────────────── */}
+      <nav className="flex items-center gap-1 overflow-x-auto pb-1">
+        {STEPS.map((s, i) => {
+          const isCompleted = i < currentStepIndex;
+          const isCurrent = i === currentStepIndex;
+          const isUpcoming = i > currentStepIndex;
+
+          return (
+            <div key={s.key} className="flex items-center gap-1">
               {i > 0 && (
-                <div className="h-px w-8 bg-muted-foreground/30" />
+                <div
+                  className={cn(
+                    'h-px w-4 md:w-8 shrink-0',
+                    isCompleted
+                      ? 'bg-primary'
+                      : 'bg-muted-foreground/20'
+                  )}
+                />
               )}
               <div
-                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
-                  step === s
-                    ? 'bg-primary text-primary-foreground'
-                    : ['settings', 'outline', 'generate'].indexOf(step) >
-                      i
-                    ? 'bg-primary/20 text-primary'
-                    : 'bg-muted text-muted-foreground'
-                }`}
+                className={cn(
+                  'flex items-center gap-1.5 px-2.5 py-1.5 rounded-full text-xs font-medium whitespace-nowrap transition-colors shrink-0',
+                  isCompleted &&
+                    'bg-primary/15 text-primary',
+                  isCurrent &&
+                    'bg-primary text-primary-foreground',
+                  isUpcoming &&
+                    'bg-muted text-muted-foreground'
+                )}
               >
-                {['settings', 'outline', 'generate'].indexOf(step) > i ? (
+                {isCompleted ? (
                   <Check className="h-3 w-3" />
                 ) : (
-                  <span>{i + 1}</span>
+                  <span className="w-3 text-center">{i + 1}</span>
                 )}
-                {s === 'settings' && 'Topic & Settings'}
-                {s === 'outline' && 'Review Outline'}
-                {s === 'generate' && 'Generate Content'}
+                <span className="hidden md:inline">{s.label}</span>
+                <span className="md:hidden">{s.shortLabel}</span>
               </div>
             </div>
-          )
-        )}
-      </div>
+          );
+        })}
+      </nav>
 
-      {/* Step 1: Topic & Settings */}
-      {step === 'settings' && (
-        <div className="space-y-6">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Sparkles className="h-5 w-5 text-primary" />
-                AI Course Generator
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="topic">Course Topic *</Label>
-                <Input
-                  id="topic"
-                  placeholder="e.g., Introduction to Project Management"
-                  value={topic}
-                  onChange={(e) => setTopic(e.target.value)}
-                />
-              </div>
+      {/* ──────────────────────────────────────────────────── */}
+      {/* STEP CONTENT                                         */}
+      {/* ──────────────────────────────────────────────────── */}
 
-              <div className="space-y-2">
-                <Label htmlFor="audience">Target Audience *</Label>
-                <Input
-                  id="audience"
-                  placeholder="e.g., New employees in the finance sector"
-                  value={audience}
-                  onChange={(e) => setAudience(e.target.value)}
-                />
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label>Difficulty</Label>
-                  <Select
-                    value={difficulty}
-                    onValueChange={(v) =>
-                      setDifficulty(
-                        v as 'beginner' | 'intermediate' | 'advanced'
-                      )
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="beginner">Beginner</SelectItem>
-                      <SelectItem value="intermediate">
-                        Intermediate
-                      </SelectItem>
-                      <SelectItem value="advanced">Advanced</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <div className="space-y-2">
-                  <Label>Language</Label>
-                  <Select
-                    value={language}
-                    onValueChange={(v) => setLanguage(v as 'ar' | 'en')}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="ar">Arabic (MSA)</SelectItem>
-                      <SelectItem value="en">English</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-3 gap-4">
-                <div className="space-y-2">
-                  <Label>Tone</Label>
-                  <Select
-                    value={tone}
-                    onValueChange={(v) =>
-                      setTone(
-                        v as 'formal' | 'conversational' | 'academic'
-                      )
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="formal">Formal</SelectItem>
-                      <SelectItem value="conversational">
-                        Conversational
-                      </SelectItem>
-                      <SelectItem value="academic">Academic</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <div className="space-y-2">
-                  <Label>Modules</Label>
-                  <Select
-                    value={String(moduleCount)}
-                    onValueChange={(v) => setModuleCount(Number(v))}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {[3, 4, 5, 6, 7].map((n) => (
-                        <SelectItem key={n} value={String(n)}>
-                          {n} modules
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <div className="space-y-2">
-                  <Label>Lessons / Module</Label>
-                  <Select
-                    value={String(lessonsPerModule)}
-                    onValueChange={(v) => setLessonsPerModule(Number(v))}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {[2, 3, 4, 5].map((n) => (
-                        <SelectItem key={n} value={String(n)}>
-                          {n} lessons
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Document upload (optional) */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">
-                Source Document (Optional)
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <DocumentUploader onExtracted={handleDocumentExtracted} />
-              {sourceChunks.length > 0 && (
-                <p className="text-xs text-muted-foreground mt-2">
-                  {sourceChunks.length} chunks extracted (
-                  {sourceChunks
-                    .reduce((s, c) => s + c.text.length, 0)
-                    .toLocaleString()}{' '}
-                  characters)
-                </p>
-              )}
-            </CardContent>
-          </Card>
-
-          <div className="flex justify-between">
-            <Button variant="outline" onClick={onCancel}>
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Cancel
-            </Button>
-            <Button
-              onClick={handleGenerateOutline}
-              disabled={
-                isGeneratingOutline || !topic.trim() || !audience.trim()
-              }
-            >
-              {isGeneratingOutline ? (
-                <>
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  Generating Outline...
-                </>
-              ) : (
-                <>
-                  Generate Outline
-                  <ArrowRight className="h-4 w-4 ml-2" />
-                </>
-              )}
-            </Button>
-          </div>
-        </div>
+      {step === 'source' && (
+        <StepSourceMaterial
+          data={sourceData}
+          onChange={setSourceData}
+          onNext={handleSourceNext}
+          onCancel={onCancel}
+          isLoading={isGeneratingDetails}
+        />
       )}
 
-      {/* Step 2: Outline Review */}
+      {step === 'details' && (
+        <StepCourseDetails
+          details={courseDetails}
+          onChange={(d) => {
+            setCourseDetails(d);
+            setObjectives(d.learning_objectives);
+          }}
+          onNext={() => setStep('objectives')}
+          onBack={() => setStep('source')}
+        />
+      )}
+
+      {step === 'objectives' && (
+        <StepLearningObjectives
+          objectives={objectives}
+          onChange={setObjectives}
+          onNext={handleObjectivesNext}
+          onBack={() => setStep('details')}
+          isLoading={isGeneratingOutline}
+        />
+      )}
+
       {step === 'outline' && outline && (
-        <div className="space-y-6">
-          <OutlineEditor
-            outline={outline}
-            onApprove={handleOutlineApproved}
-            onBack={() => setStep('settings')}
-          />
-        </div>
+        <StepOutlineEditor
+          outline={outline}
+          onChange={setOutline}
+          onNext={() => setStep('options')}
+          onBack={() => setStep('objectives')}
+        />
       )}
 
-      {/* Step 3: Generation */}
+      {step === 'options' && outline && (
+        <StepContentOptions
+          options={contentOptions}
+          onChange={setContentOptions}
+          outline={outline}
+          onGenerate={() => setStep('generate')}
+          onBack={() => setStep('outline')}
+        />
+      )}
+
       {step === 'generate' && outline && (
-        <GenerationProgress
+        <StepGeneration
           courseId={courseId}
           outline={outline}
-          language={language}
-          difficulty={difficulty}
-          audience={audience}
+          options={contentOptions}
+          language={sourceData.language}
+          difficulty={courseDetails.difficulty}
+          audience={courseDetails.audience}
           onComplete={onComplete}
-          onBack={() => setStep('outline')}
+          onBack={() => setStep('options')}
         />
       )}
     </div>

--- a/src/components/authoring/ai/OutlineEditor.tsx
+++ b/src/components/authoring/ai/OutlineEditor.tsx
@@ -80,6 +80,7 @@ export function OutlineEditor({
             order: 0,
             suggested_blocks: [BlockType.TEXT, BlockType.ACCORDION, BlockType.MULTIPLE_CHOICE],
             estimated_duration_minutes: 10,
+            topics: [],
           },
         ],
       });
@@ -112,6 +113,7 @@ export function OutlineEditor({
         order: lessons.length,
         suggested_blocks: [BlockType.TEXT, BlockType.ACCORDION, BlockType.MULTIPLE_CHOICE],
         estimated_duration_minutes: 10,
+        topics: [],
       });
       return next;
     });

--- a/src/components/authoring/ai/StepContentOptions.tsx
+++ b/src/components/authoring/ai/StepContentOptions.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import {
+  ArrowLeft,
+  Blocks,
+  Image as ImageIcon,
+  ClipboardCheck,
+  Sparkles,
+} from 'lucide-react';
+import type { ContentOptions, CourseOutline } from '@/types/authoring';
+
+interface StepContentOptionsProps {
+  options: ContentOptions;
+  onChange: (options: ContentOptions) => void;
+  outline: CourseOutline;
+  onGenerate: () => void;
+  onBack: () => void;
+}
+
+export function StepContentOptions({
+  options,
+  onChange,
+  outline,
+  onGenerate,
+  onBack,
+}: StepContentOptionsProps) {
+  const totalLessons = outline.modules.reduce(
+    (s, m) => s + m.lessons.length,
+    0
+  );
+  // Rough estimate: ~2 images per lesson × $0.04
+  const estimatedImageCost = (totalLessons * 2 * 0.04).toFixed(2);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">
+          Almost there! Configure your content.
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Choose how your lessons will be generated. You can always edit
+          everything after generation.
+        </p>
+      </div>
+
+      {/* Content Format */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Blocks className="h-4 w-4" />
+            Content Format
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <RadioGroup
+            value={options.content_format}
+            onValueChange={(v) =>
+              onChange({
+                ...options,
+                content_format: v as 'interactive' | 'text_only',
+              })
+            }
+            className="space-y-3"
+          >
+            <label
+              htmlFor="format-interactive"
+              className="flex cursor-pointer items-center gap-3 rounded-lg border border-border px-4 py-3 transition-colors hover:bg-muted/50 has-[data-state=checked]:border-primary has-[data-state=checked]:bg-primary/5"
+            >
+              <RadioGroupItem value="interactive" id="format-interactive" />
+              <div>
+                <p className="text-sm font-medium">
+                  Text and interactive content
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  AI will create text, accordions, tabs, process blocks, and
+                  knowledge checks.
+                </p>
+              </div>
+            </label>
+
+            <label
+              htmlFor="format-text"
+              className="flex cursor-pointer items-center gap-3 rounded-lg border border-border px-4 py-3 transition-colors hover:bg-muted/50 has-[data-state=checked]:border-primary has-[data-state=checked]:bg-primary/5"
+            >
+              <RadioGroupItem value="text_only" id="format-text" />
+              <div>
+                <p className="text-sm font-medium">Text only</p>
+                <p className="text-xs text-muted-foreground">
+                  AI will create text-based content only. You can add
+                  interactive blocks manually later.
+                </p>
+              </div>
+            </label>
+          </RadioGroup>
+        </CardContent>
+      </Card>
+
+      {/* AI Images */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <ImageIcon className="h-4 w-4" />
+            AI Images
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium">
+                Generate images for this course
+              </p>
+              <p className="text-xs text-muted-foreground">
+                AI will create relevant images using DALL-E 3.
+                {options.generate_images && (
+                  <> Estimated cost: ~${estimatedImageCost}</>
+                )}
+              </p>
+            </div>
+            <Switch
+              checked={options.generate_images}
+              onCheckedChange={(checked) =>
+                onChange({ ...options, generate_images: checked })
+              }
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Assessment Density */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <ClipboardCheck className="h-4 w-4" />
+            Assessments
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <RadioGroup
+            value={options.assessment_density}
+            onValueChange={(v) =>
+              onChange({
+                ...options,
+                assessment_density: v as
+                  | 'per_lesson'
+                  | 'per_module'
+                  | 'none',
+              })
+            }
+            className="space-y-3"
+          >
+            <label
+              htmlFor="assess-lesson"
+              className="flex cursor-pointer items-center gap-3 rounded-lg border border-border px-4 py-3 transition-colors hover:bg-muted/50 has-[data-state=checked]:border-primary has-[data-state=checked]:bg-primary/5"
+            >
+              <RadioGroupItem value="per_lesson" id="assess-lesson" />
+              <div>
+                <p className="text-sm font-medium">Quiz every lesson</p>
+                <p className="text-xs text-muted-foreground">
+                  Knowledge check at the end of each lesson.
+                </p>
+              </div>
+            </label>
+
+            <label
+              htmlFor="assess-module"
+              className="flex cursor-pointer items-center gap-3 rounded-lg border border-border px-4 py-3 transition-colors hover:bg-muted/50 has-[data-state=checked]:border-primary has-[data-state=checked]:bg-primary/5"
+            >
+              <RadioGroupItem value="per_module" id="assess-module" />
+              <div>
+                <p className="text-sm font-medium">Quiz every module</p>
+                <p className="text-xs text-muted-foreground">
+                  Assessment at the end of each module only.
+                </p>
+              </div>
+            </label>
+
+            <label
+              htmlFor="assess-none"
+              className="flex cursor-pointer items-center gap-3 rounded-lg border border-border px-4 py-3 transition-colors hover:bg-muted/50 has-[data-state=checked]:border-primary has-[data-state=checked]:bg-primary/5"
+            >
+              <RadioGroupItem value="none" id="assess-none" />
+              <div>
+                <p className="text-sm font-medium">No quizzes</p>
+                <p className="text-xs text-muted-foreground">
+                  Content only, no assessments. You can add quizzes manually
+                  later.
+                </p>
+              </div>
+            </label>
+          </RadioGroup>
+        </CardContent>
+      </Card>
+
+      {/* Actions */}
+      <div className="flex justify-between">
+        <Button variant="outline" onClick={onBack}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+        <Button onClick={onGenerate}>
+          <Sparkles className="h-4 w-4 mr-2" />
+          Create course draft
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/authoring/ai/StepCourseDetails.tsx
+++ b/src/components/authoring/ai/StepCourseDetails.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  ArrowLeft,
+  ArrowRight,
+  BookOpen,
+  Clock,
+  FileText,
+  GraduationCap,
+  Sparkles,
+} from 'lucide-react';
+import type { CourseDetails, CourseLength } from '@/types/authoring';
+import { COURSE_LENGTH_CONFIG } from '@/types/authoring';
+import { cn } from '@/lib/utils';
+
+interface StepCourseDetailsProps {
+  details: CourseDetails;
+  onChange: (details: CourseDetails) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const LENGTH_ICONS: Record<CourseLength, React.ReactNode> = {
+  micro: <FileText className="h-6 w-6" />,
+  short: <BookOpen className="h-6 w-6" />,
+  standard: <GraduationCap className="h-6 w-6" />,
+  extended: <Clock className="h-6 w-6" />,
+};
+
+export function StepCourseDetails({
+  details,
+  onChange,
+  onNext,
+  onBack,
+}: StepCourseDetailsProps) {
+  const updateField = <K extends keyof CourseDetails>(
+    field: K,
+    value: CourseDetails[K]
+  ) => {
+    onChange({ ...details, [field]: value });
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">
+          Take a look at the course details we&apos;ve generated.
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Refine the course information and learning objectives to match your
+          vision. We&apos;ll build on this to create your course outline.
+        </p>
+      </div>
+
+      {/* Course Length Cards */}
+      <div className="space-y-3">
+        <Label className="text-sm font-medium">Course Length</Label>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          {(Object.keys(COURSE_LENGTH_CONFIG) as CourseLength[]).map((key) => {
+            const config = COURSE_LENGTH_CONFIG[key];
+            const isSelected = details.suggested_length === key;
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => updateField('suggested_length', key)}
+                className={cn(
+                  'flex flex-col items-center gap-2 rounded-xl border-2 p-4 text-center transition-all hover:shadow-sm',
+                  isSelected
+                    ? 'border-primary bg-primary/5 text-primary shadow-sm'
+                    : 'border-border bg-card text-muted-foreground hover:border-primary/30'
+                )}
+              >
+                <span
+                  className={cn(
+                    isSelected ? 'text-primary' : 'text-muted-foreground'
+                  )}
+                >
+                  {LENGTH_ICONS[key]}
+                </span>
+                <span className="text-sm font-semibold">{config.label}</span>
+                <span className="text-xs opacity-70">{config.description}</span>
+                <span className="text-xs opacity-50">{config.duration}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Course Information */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between pb-3">
+          <CardTitle className="text-base">Course Information</CardTitle>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm" className="gap-1.5">
+                <Sparkles className="h-3.5 w-3.5" />
+                Edit with AI
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem disabled>
+                <Sparkles className="h-4 w-4 mr-2" />
+                Rewrite section (coming soon)
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="topic" className="text-xs text-muted-foreground">
+              Course Topic
+            </Label>
+            <Input
+              id="topic"
+              value={details.topic}
+              onChange={(e) => updateField('topic', e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="tone" className="text-xs text-muted-foreground">
+              Tone
+            </Label>
+            <Input
+              id="tone"
+              value={details.tone}
+              onChange={(e) => updateField('tone', e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="audience" className="text-xs text-muted-foreground">
+              Audience
+            </Label>
+            <Textarea
+              id="audience"
+              value={details.audience}
+              onChange={(e) => updateField('audience', e.target.value)}
+              rows={2}
+              className="resize-none"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="goals" className="text-xs text-muted-foreground">
+              Goals
+            </Label>
+            <Textarea
+              id="goals"
+              value={details.goals}
+              onChange={(e) => updateField('goals', e.target.value)}
+              rows={2}
+              className="resize-none"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-xs text-muted-foreground">Difficulty</Label>
+            <Select
+              value={details.difficulty}
+              onValueChange={(v) =>
+                updateField(
+                  'difficulty',
+                  v as 'beginner' | 'intermediate' | 'advanced'
+                )
+              }
+            >
+              <SelectTrigger className="h-9">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="beginner">Beginner</SelectItem>
+                <SelectItem value="intermediate">Intermediate</SelectItem>
+                <SelectItem value="advanced">Advanced</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Actions */}
+      <div className="flex justify-between">
+        <Button variant="outline" onClick={onBack}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+        <Button onClick={onNext}>
+          Review learning objectives
+          <ArrowRight className="h-4 w-4 ml-2" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/authoring/ai/StepGeneration.tsx
+++ b/src/components/authoring/ai/StepGeneration.tsx
@@ -1,0 +1,521 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { Badge } from '@/components/ui/badge';
+import {
+  ArrowLeft,
+  Check,
+  Loader2,
+  AlertCircle,
+  Sparkles,
+  Clock,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { useEditorStore } from '@/stores/editor.store';
+import type {
+  Block,
+  ContentOptions,
+  CourseOutline,
+} from '@/types/authoring';
+import { v4 as uuidv4 } from 'uuid';
+import { resolveGenerateMarker } from '@/components/authoring/ai/AIImageGenerator';
+
+interface StepGenerationProps {
+  courseId: number;
+  outline: CourseOutline;
+  options: ContentOptions;
+  language: 'ar' | 'en';
+  difficulty: 'beginner' | 'intermediate' | 'advanced';
+  audience: string;
+  onComplete: () => void;
+  onBack: () => void;
+}
+
+interface LessonStatus {
+  moduleIndex: number;
+  lessonIndex: number;
+  moduleTitle: string;
+  lessonTitle: string;
+  status: 'pending' | 'generating' | 'generating_images' | 'done' | 'error';
+  blocks: Block[];
+  error?: string;
+  imageCount?: number;
+  imagesResolved?: number;
+  startTime?: number;
+  endTime?: number;
+}
+
+export function StepGeneration({
+  courseId,
+  outline,
+  options,
+  language,
+  difficulty,
+  audience,
+  onComplete,
+  onBack,
+}: StepGenerationProps) {
+  const loadContent = useEditorStore((s) => s.loadContent);
+  const [lessons, setLessons] = useState<LessonStatus[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [isDone, setIsDone] = useState(false);
+  const abortRef = useRef(false);
+  const avgTimeRef = useRef(0);
+
+  // Build flat lesson list from outline
+  useEffect(() => {
+    const flat: LessonStatus[] = [];
+    outline.modules.forEach((mod, mi) => {
+      mod.lessons.forEach((les, li) => {
+        flat.push({
+          moduleIndex: mi,
+          lessonIndex: li,
+          moduleTitle: mod.title,
+          lessonTitle: les.title,
+          status: 'pending',
+          blocks: [],
+        });
+      });
+    });
+    setLessons(flat);
+  }, [outline]);
+
+  // Auto-start generation when lessons are loaded
+  const hasStarted = useRef(false);
+  useEffect(() => {
+    if (lessons.length > 0 && !hasStarted.current && !isGenerating && !isDone) {
+      hasStarted.current = true;
+      generateAll();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lessons.length]);
+
+  const generateAll = useCallback(async () => {
+    setIsGenerating(true);
+    abortRef.current = false;
+    const durations: number[] = [];
+
+    for (let i = 0; i < lessons.length; i++) {
+      if (abortRef.current) break;
+
+      const lesson = lessons[i];
+      const outlineLesson =
+        outline.modules[lesson.moduleIndex].lessons[lesson.lessonIndex];
+
+      const lessonStart = Date.now();
+
+      // Mark as generating
+      setLessons((prev) =>
+        prev.map((l, idx) =>
+          idx === i ? { ...l, status: 'generating', startTime: lessonStart } : l
+        )
+      );
+
+      try {
+        // Determine suggested blocks based on content options
+        let suggestedBlocks = outlineLesson.suggested_blocks || [];
+        if (options.content_format === 'text_only') {
+          suggestedBlocks = suggestedBlocks.filter(
+            (b) => b === 'text' || b === 'divider' || b === 'cover'
+          );
+          if (suggestedBlocks.length === 0) suggestedBlocks = ['text', 'cover'] as any;
+        }
+        if (options.assessment_density === 'none') {
+          suggestedBlocks = suggestedBlocks.filter(
+            (b) => b !== 'multiple_choice' && b !== 'true_false'
+          );
+        }
+
+        const res = await fetch('/api/ai/generate-lesson', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            lesson_title: outlineLesson.title,
+            lesson_description: outlineLesson.description,
+            module_title: outline.modules[lesson.moduleIndex].title,
+            course_title: outline.title,
+            suggested_blocks: suggestedBlocks,
+            language,
+            difficulty,
+            audience,
+            previous_context:
+              i > 0
+                ? `Previous lesson: ${lessons[i - 1].lessonTitle}`
+                : undefined,
+          }),
+        });
+
+        if (!res.ok) {
+          throw new Error('Failed to generate lesson');
+        }
+
+        // Read streaming response
+        const reader = res.body?.getReader();
+        const decoder = new TextDecoder();
+        let fullText = '';
+
+        if (reader) {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            fullText += decoder.decode(value, { stream: true });
+          }
+        }
+
+        // Parse the complete JSON response
+        let blocks: Block[] = [];
+        try {
+          let text = fullText.trim();
+          if (text.startsWith('```json')) text = text.slice(7);
+          if (text.startsWith('```')) text = text.slice(3);
+          if (text.endsWith('```')) text = text.slice(0, -3);
+          blocks = JSON.parse(text.trim());
+          if (!Array.isArray(blocks)) blocks = [];
+        } catch {
+          blocks = [
+            {
+              id: uuidv4(),
+              type: 'text',
+              order: 0,
+              visible: true,
+              locked: false,
+              metadata: {
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                created_by: 'ai',
+              },
+              data: {
+                content: `<p>${fullText.slice(0, 500)}</p>`,
+                alignment: 'start',
+                direction: language === 'ar' ? 'rtl' : 'ltr',
+              },
+            } as Block,
+          ];
+        }
+
+        // Resolve GENERATE: markers in image and cover blocks
+        if (options.generate_images) {
+          const imageMarkers = blocks.filter(
+            (b) =>
+              (b.type === 'image' &&
+                (b.data as { src?: string }).src?.startsWith('GENERATE:')) ||
+              (b.type === 'cover' &&
+                (b.data as { background_image?: string }).background_image?.startsWith(
+                  'GENERATE:'
+                ))
+          );
+
+          if (imageMarkers.length > 0) {
+            setLessons((prev) =>
+              prev.map((l, idx) =>
+                idx === i
+                  ? {
+                      ...l,
+                      status: 'generating_images',
+                      imageCount: imageMarkers.length,
+                      imagesResolved: 0,
+                    }
+                  : l
+              )
+            );
+
+            let resolved = 0;
+            for (const block of blocks) {
+              if (abortRef.current) break;
+
+              const blockData = block.data as Record<string, unknown>;
+
+              if (
+                block.type === 'image' &&
+                typeof blockData.src === 'string' &&
+                blockData.src.startsWith('GENERATE:')
+              ) {
+                const url = await resolveGenerateMarker(blockData.src, false);
+                if (url) blockData.src = url;
+                resolved++;
+                setLessons((prev) =>
+                  prev.map((l, idx) =>
+                    idx === i ? { ...l, imagesResolved: resolved } : l
+                  )
+                );
+              }
+
+              if (
+                block.type === 'cover' &&
+                typeof blockData.background_image === 'string' &&
+                blockData.background_image.startsWith('GENERATE:')
+              ) {
+                const url = await resolveGenerateMarker(
+                  blockData.background_image,
+                  true
+                );
+                if (url) blockData.background_image = url;
+                resolved++;
+                setLessons((prev) =>
+                  prev.map((l, idx) =>
+                    idx === i ? { ...l, imagesResolved: resolved } : l
+                  )
+                );
+              }
+            }
+          }
+        } else {
+          // Remove GENERATE: markers if images are disabled
+          for (const block of blocks) {
+            const blockData = block.data as Record<string, unknown>;
+            if (
+              block.type === 'image' &&
+              typeof blockData.src === 'string' &&
+              blockData.src.startsWith('GENERATE:')
+            ) {
+              blockData.src = '';
+            }
+            if (
+              block.type === 'cover' &&
+              typeof blockData.background_image === 'string' &&
+              blockData.background_image.startsWith('GENERATE:')
+            ) {
+              blockData.background_image = '';
+            }
+          }
+        }
+
+        const lessonEnd = Date.now();
+        durations.push(lessonEnd - lessonStart);
+        avgTimeRef.current =
+          durations.reduce((a, b) => a + b, 0) / durations.length;
+
+        setLessons((prev) =>
+          prev.map((l, idx) =>
+            idx === i
+              ? { ...l, status: 'done', blocks, endTime: lessonEnd }
+              : l
+          )
+        );
+      } catch (error) {
+        setLessons((prev) =>
+          prev.map((l, idx) =>
+            idx === i
+              ? {
+                  ...l,
+                  status: 'error',
+                  error:
+                    error instanceof Error
+                      ? error.message
+                      : 'Generation failed',
+                }
+              : l
+          )
+        );
+      }
+    }
+
+    setIsGenerating(false);
+    setIsDone(true);
+  }, [lessons.length, outline, options, language, difficulty, audience]);
+
+  const handleApplyToEditor = () => {
+    const modules = outline.modules.map((mod, mi) => ({
+      id: uuidv4(),
+      title: mod.title,
+      order: mi,
+      is_locked: false,
+      lessons: mod.lessons.map((les, li) => {
+        const generated = lessons.find(
+          (l) => l.moduleIndex === mi && l.lessonIndex === li
+        );
+        return {
+          id: uuidv4(),
+          title: les.title,
+          order: li,
+          is_locked: false,
+          blocks: (generated?.blocks || []).map((b, bi) => ({
+            ...b,
+            id: b.id || uuidv4(),
+            order: bi,
+          })),
+        };
+      }),
+    }));
+
+    loadContent(
+      courseId,
+      {
+        modules,
+        settings: {
+          theme: {
+            primary_color: '#1a73e8',
+            secondary_color: '#f59e0b',
+            background_color: '#ffffff',
+            text_color: '#1f2937',
+            font_family: 'cairo',
+            border_radius: 'medium',
+            cover_style: 'gradient',
+          },
+          navigation: 'sequential',
+          show_progress_bar: true,
+          show_lesson_list: true,
+          completion_criteria: 'all_blocks',
+          language,
+          direction: language === 'ar' ? 'rtl' : 'ltr',
+        },
+      },
+      '',
+      1
+    );
+
+    toast.success('Course content loaded into editor');
+    onComplete();
+  };
+
+  const completedCount = lessons.filter((l) => l.status === 'done').length;
+  const errorCount = lessons.filter((l) => l.status === 'error').length;
+  const totalCount = lessons.length;
+  const progressPercent =
+    totalCount > 0
+      ? Math.round(((completedCount + errorCount) / totalCount) * 100)
+      : 0;
+
+  // Estimated time remaining
+  const remainingLessons = totalCount - completedCount - errorCount;
+  const estimatedSecondsRemaining =
+    avgTimeRef.current > 0
+      ? Math.round((remainingLessons * avgTimeRef.current) / 1000)
+      : 0;
+
+  const currentLesson = lessons.find((l) => l.status === 'generating' || l.status === 'generating_images');
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-primary" />
+            Generating Course Content
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <div className="flex justify-between text-sm">
+              <span>
+                {completedCount} of {totalCount} lessons generated
+              </span>
+              <span>{progressPercent}%</span>
+            </div>
+            <Progress value={progressPercent} className="h-2" />
+          </div>
+
+          {/* Current lesson indicator */}
+          {currentLesson && (
+            <p className="text-sm text-muted-foreground text-center">
+              Generating: <strong>{currentLesson.lessonTitle}</strong>
+            </p>
+          )}
+
+          {/* Time estimate */}
+          {isGenerating && estimatedSecondsRemaining > 0 && (
+            <p className="text-xs text-muted-foreground text-center flex items-center justify-center gap-1">
+              <Clock className="h-3 w-3" />
+              ~{estimatedSecondsRemaining < 60
+                ? `${estimatedSecondsRemaining}s`
+                : `${Math.ceil(estimatedSecondsRemaining / 60)}min`}{' '}
+              remaining
+            </p>
+          )}
+
+          {isGenerating && !currentLesson && (
+            <p className="text-sm text-muted-foreground text-center">
+              Preparing to generate lessons...
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Lesson list */}
+      <div className="space-y-2">
+        {lessons.map((lesson, i) => (
+          <div
+            key={i}
+            className={`flex items-center gap-3 px-4 py-2.5 rounded-lg border transition-all ${
+              lesson.status === 'done'
+                ? 'bg-card border-green-200 dark:border-green-800'
+                : lesson.status === 'generating' || lesson.status === 'generating_images'
+                  ? 'bg-primary/5 border-primary/20'
+                  : lesson.status === 'error'
+                    ? 'bg-destructive/5 border-destructive/20'
+                    : 'bg-card border-border opacity-60'
+            }`}
+          >
+            {lesson.status === 'pending' && (
+              <div className="h-5 w-5 rounded-full border-2 border-muted-foreground/30 shrink-0" />
+            )}
+            {lesson.status === 'generating' && (
+              <Loader2 className="h-5 w-5 text-primary animate-spin shrink-0" />
+            )}
+            {lesson.status === 'generating_images' && (
+              <Loader2 className="h-5 w-5 text-amber-500 animate-spin shrink-0" />
+            )}
+            {lesson.status === 'done' && (
+              <div className="h-5 w-5 rounded-full bg-green-500 flex items-center justify-center shrink-0">
+                <Check className="h-3 w-3 text-white" />
+              </div>
+            )}
+            {lesson.status === 'error' && (
+              <AlertCircle className="h-5 w-5 text-destructive shrink-0" />
+            )}
+
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium truncate">
+                {lesson.lessonTitle}
+              </p>
+              <p className="text-xs text-muted-foreground truncate">
+                {lesson.moduleTitle}
+              </p>
+            </div>
+
+            {lesson.status === 'generating_images' && (
+              <Badge
+                variant="outline"
+                className="shrink-0 text-amber-600 border-amber-300"
+              >
+                Images {lesson.imagesResolved || 0}/{lesson.imageCount || 0}
+              </Badge>
+            )}
+            {lesson.status === 'done' && (
+              <Badge variant="secondary" className="shrink-0">
+                {lesson.blocks.length} blocks
+              </Badge>
+            )}
+            {lesson.status === 'error' && (
+              <Badge variant="destructive" className="shrink-0">
+                Error
+              </Badge>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-between">
+        <Button
+          variant="outline"
+          onClick={onBack}
+          disabled={isGenerating}
+        >
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+
+        {isDone && (
+          <Button onClick={handleApplyToEditor}>
+            Open in Editor
+            <Check className="h-4 w-4 ml-2" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/authoring/ai/StepLearningObjectives.tsx
+++ b/src/components/authoring/ai/StepLearningObjectives.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import { useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  ArrowLeft,
+  ArrowRight,
+  GripVertical,
+  Plus,
+  Sparkles,
+  Trash2,
+  Target,
+} from 'lucide-react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+interface StepLearningObjectivesProps {
+  objectives: string[];
+  onChange: (objectives: string[]) => void;
+  onNext: () => void;
+  onBack: () => void;
+  isLoading: boolean;
+}
+
+interface SortableObjectiveProps {
+  id: string;
+  index: number;
+  value: string;
+  onChange: (value: string) => void;
+  onDelete: () => void;
+  canDelete: boolean;
+}
+
+function SortableObjective({
+  id,
+  index,
+  value,
+  onChange,
+  onDelete,
+  canDelete,
+}: SortableObjectiveProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-2 group ${
+        isDragging ? 'opacity-50' : ''
+      }`}
+    >
+      <button
+        type="button"
+        className="shrink-0 cursor-grab active:cursor-grabbing touch-none text-muted-foreground/50 hover:text-muted-foreground"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <span className="text-xs text-muted-foreground w-5 shrink-0 text-center">
+        {index + 1}.
+      </span>
+      <Input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-9 text-sm"
+        placeholder="e.g., Identify key B2B sales activities..."
+      />
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 shrink-0 opacity-0 group-hover:opacity-100 text-destructive"
+        onClick={onDelete}
+        disabled={!canDelete}
+        aria-label="Remove objective"
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}
+
+export function StepLearningObjectives({
+  objectives,
+  onChange,
+  onNext,
+  onBack,
+  isLoading,
+}: StepLearningObjectivesProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const objectiveIds = objectives.map((_, i) => `obj-${i}`);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const oldIndex = objectiveIds.indexOf(active.id as string);
+      const newIndex = objectiveIds.indexOf(over.id as string);
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const reordered = [...objectives];
+      const [moved] = reordered.splice(oldIndex, 1);
+      reordered.splice(newIndex, 0, moved);
+      onChange(reordered);
+    },
+    [objectives, objectiveIds, onChange]
+  );
+
+  const updateObjective = (index: number, value: string) => {
+    const updated = [...objectives];
+    updated[index] = value;
+    onChange(updated);
+  };
+
+  const deleteObjective = (index: number) => {
+    if (objectives.length <= 1) return;
+    onChange(objectives.filter((_, i) => i !== index));
+  };
+
+  const addObjective = () => {
+    onChange([...objectives, '']);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold flex items-center gap-2">
+          <Target className="h-5 w-5 text-primary" />
+          Review the learning objectives
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          After completing this course, learners should understand or be able to:
+        </p>
+      </div>
+
+      {/* Objectives editor */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between pb-3">
+          <CardTitle className="text-base">Learning Objectives</CardTitle>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm" className="gap-1.5">
+                <Sparkles className="h-3.5 w-3.5" />
+                Edit with AI
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem disabled>
+                <Sparkles className="h-4 w-4 mr-2" />
+                Rewrite all objectives (coming soon)
+              </DropdownMenuItem>
+              <DropdownMenuItem disabled>
+                <Plus className="h-4 w-4 mr-2" />
+                Add more objectives (coming soon)
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={objectiveIds}
+              strategy={verticalListSortingStrategy}
+            >
+              {objectives.map((obj, i) => (
+                <SortableObjective
+                  key={objectiveIds[i]}
+                  id={objectiveIds[i]}
+                  index={i}
+                  value={obj}
+                  onChange={(v) => updateObjective(i, v)}
+                  onDelete={() => deleteObjective(i)}
+                  canDelete={objectives.length > 1}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
+
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-xs ml-9"
+            onClick={addObjective}
+          >
+            <Plus className="h-3 w-3 mr-1" />
+            Add learning objective
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Actions */}
+      <div className="flex justify-between">
+        <Button variant="outline" onClick={onBack} disabled={isLoading}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+        <Button onClick={onNext} disabled={isLoading}>
+          {isLoading ? (
+            <>
+              <span className="h-4 w-4 mr-2 animate-spin rounded-full border-2 border-current border-t-transparent" />
+              Generating outline...
+            </>
+          ) : (
+            <>
+              Generate course outline
+              <ArrowRight className="h-4 w-4 ml-2" />
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/authoring/ai/StepOutlineEditor.tsx
+++ b/src/components/authoring/ai/StepOutlineEditor.tsx
@@ -1,0 +1,534 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  ArrowLeft,
+  ArrowRight,
+  BookOpen,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  GripVertical,
+  Plus,
+  Sparkles,
+  Trash2,
+  X,
+} from 'lucide-react';
+import { BlockType } from '@/types/authoring';
+import type { CourseOutline, CourseOutlineLesson } from '@/types/authoring';
+import { cn } from '@/lib/utils';
+
+interface StepOutlineEditorProps {
+  outline: CourseOutline;
+  onChange: (outline: CourseOutline) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+export function StepOutlineEditor({
+  outline,
+  onChange,
+  onNext,
+  onBack,
+}: StepOutlineEditorProps) {
+  const [selectedModuleIndex, setSelectedModuleIndex] = useState(0);
+  const [selectedLessonIndex, setSelectedLessonIndex] = useState(0);
+  const [expandedModules, setExpandedModules] = useState<Set<number>>(
+    new Set(outline.modules.map((_, i) => i))
+  );
+
+  const toggleModule = (index: number) => {
+    setExpandedModules((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  };
+
+  const selectLesson = (moduleIndex: number, lessonIndex: number) => {
+    setSelectedModuleIndex(moduleIndex);
+    setSelectedLessonIndex(lessonIndex);
+  };
+
+  const selectedLesson: CourseOutlineLesson | null =
+    outline.modules[selectedModuleIndex]?.lessons[selectedLessonIndex] ?? null;
+
+  // Mutation helpers
+  const updateOutline = (mutator: (draft: CourseOutline) => void) => {
+    const draft = structuredClone(outline);
+    mutator(draft);
+    onChange(draft);
+  };
+
+  const updateModuleTitle = (mi: number, title: string) => {
+    updateOutline((d) => {
+      d.modules[mi].title = title;
+    });
+  };
+
+  const updateLessonField = <K extends keyof CourseOutlineLesson>(
+    mi: number,
+    li: number,
+    field: K,
+    value: CourseOutlineLesson[K]
+  ) => {
+    updateOutline((d) => {
+      d.modules[mi].lessons[li][field] = value;
+    });
+  };
+
+  const updateLessonTopic = (
+    mi: number,
+    li: number,
+    topicIndex: number,
+    value: string
+  ) => {
+    updateOutline((d) => {
+      d.modules[mi].lessons[li].topics[topicIndex] = value;
+    });
+  };
+
+  const addLessonTopic = (mi: number, li: number) => {
+    updateOutline((d) => {
+      if (!d.modules[mi].lessons[li].topics) {
+        d.modules[mi].lessons[li].topics = [];
+      }
+      d.modules[mi].lessons[li].topics.push('');
+    });
+  };
+
+  const deleteLessonTopic = (mi: number, li: number, topicIndex: number) => {
+    updateOutline((d) => {
+      d.modules[mi].lessons[li].topics.splice(topicIndex, 1);
+    });
+  };
+
+  const addModule = () => {
+    updateOutline((d) => {
+      const newIndex = d.modules.length;
+      d.modules.push({
+        title: `Module ${newIndex + 1}`,
+        description: '',
+        order: newIndex,
+        lessons: [
+          {
+            title: 'New Lesson',
+            description: '',
+            order: 0,
+            suggested_blocks: [
+              BlockType.TEXT,
+              BlockType.ACCORDION,
+              BlockType.MULTIPLE_CHOICE,
+            ],
+            estimated_duration_minutes: 10,
+            topics: [],
+          },
+        ],
+      });
+      setExpandedModules((prev) => {
+        const next = new Set(prev);
+        next.add(newIndex);
+        return next;
+      });
+      setSelectedModuleIndex(newIndex);
+      setSelectedLessonIndex(0);
+    });
+  };
+
+  const deleteModule = (mi: number) => {
+    if (outline.modules.length <= 1) return;
+    updateOutline((d) => {
+      d.modules.splice(mi, 1);
+      d.modules.forEach((m, i) => (m.order = i));
+    });
+    if (selectedModuleIndex >= outline.modules.length - 1) {
+      setSelectedModuleIndex(Math.max(0, outline.modules.length - 2));
+      setSelectedLessonIndex(0);
+    }
+  };
+
+  const addLesson = (mi: number) => {
+    updateOutline((d) => {
+      const lessons = d.modules[mi].lessons;
+      lessons.push({
+        title: 'New Lesson',
+        description: '',
+        order: lessons.length,
+        suggested_blocks: [
+          BlockType.TEXT,
+          BlockType.ACCORDION,
+          BlockType.MULTIPLE_CHOICE,
+        ],
+        estimated_duration_minutes: 10,
+        topics: [],
+      });
+    });
+  };
+
+  const deleteLesson = (mi: number, li: number) => {
+    if (outline.modules[mi].lessons.length <= 1) return;
+    updateOutline((d) => {
+      d.modules[mi].lessons.splice(li, 1);
+      d.modules[mi].lessons.forEach((l, i) => (l.order = i));
+    });
+    if (
+      selectedModuleIndex === mi &&
+      selectedLessonIndex >= outline.modules[mi].lessons.length - 1
+    ) {
+      setSelectedLessonIndex(
+        Math.max(0, outline.modules[mi].lessons.length - 2)
+      );
+    }
+  };
+
+  const totalLessons = outline.modules.reduce(
+    (s, m) => s + m.lessons.length,
+    0
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold">
+            Your course is coming together!
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            We&apos;ve organized your content into a course outline. Edit and
+            refine it before generating lessons.
+          </p>
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm" className="gap-1.5 shrink-0">
+              <Sparkles className="h-3.5 w-3.5" />
+              Edit with AI
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem disabled>
+              <Sparkles className="h-4 w-4 mr-2" />
+              Restructure outline (coming soon)
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {/* Summary badges */}
+      <div className="flex flex-wrap gap-2">
+        <Badge variant="secondary">
+          {outline.modules.length} Modules
+        </Badge>
+        <Badge variant="secondary">{totalLessons} Lessons</Badge>
+        <Badge variant="secondary">
+          <Clock className="h-3 w-3 mr-1" />~
+          {outline.estimated_duration_minutes} min
+        </Badge>
+        <Badge variant="outline">{outline.difficulty}</Badge>
+        <Badge variant="outline">
+          {outline.language === 'ar' ? 'Arabic' : 'English'}
+        </Badge>
+      </div>
+
+      {/* Split panel */}
+      <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-4 min-h-[400px]">
+        {/* LEFT SIDEBAR — Module/Lesson tree */}
+        <Card className="overflow-hidden">
+          <CardHeader className="py-3 px-4">
+            <CardTitle className="text-sm flex items-center gap-1.5">
+              <BookOpen className="h-4 w-4" />
+              Outline
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <div className="max-h-[450px] overflow-y-auto">
+              {outline.modules.map((mod, mi) => (
+                <div key={mi}>
+                  {/* Module header */}
+                  <div
+                    className="flex items-center gap-1.5 px-3 py-2 bg-muted/30 border-b cursor-pointer hover:bg-muted/50 transition-colors"
+                    onClick={() => toggleModule(mi)}
+                  >
+                    <GripVertical className="h-3.5 w-3.5 text-muted-foreground/40 shrink-0" />
+                    {expandedModules.has(mi) ? (
+                      <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+                    ) : (
+                      <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+                    )}
+                    <span className="text-xs font-medium truncate flex-1">
+                      {mod.title}
+                    </span>
+                    <Badge
+                      variant="secondary"
+                      className="text-[10px] h-4 shrink-0"
+                    >
+                      {mod.lessons.length}
+                    </Badge>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-5 w-5 shrink-0 text-destructive opacity-0 group-hover:opacity-100"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        deleteModule(mi);
+                      }}
+                      disabled={outline.modules.length <= 1}
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </Button>
+                  </div>
+
+                  {/* Lessons within module */}
+                  {expandedModules.has(mi) && (
+                    <div>
+                      {mod.lessons.map((les, li) => {
+                        const isActive =
+                          selectedModuleIndex === mi &&
+                          selectedLessonIndex === li;
+                        return (
+                          <button
+                            key={li}
+                            type="button"
+                            onClick={() => selectLesson(mi, li)}
+                            className={cn(
+                              'w-full flex items-center gap-2 px-4 pl-8 py-2 text-left text-xs border-b transition-colors',
+                              isActive
+                                ? 'bg-primary/5 text-primary border-l-2 border-l-primary'
+                                : 'hover:bg-muted/30 text-foreground'
+                            )}
+                          >
+                            <span className="truncate flex-1">
+                              {les.title}
+                            </span>
+                            <span className="text-[10px] text-muted-foreground shrink-0">
+                              {les.estimated_duration_minutes}m
+                            </span>
+                          </button>
+                        );
+                      })}
+                      <button
+                        type="button"
+                        onClick={() => addLesson(mi)}
+                        className="w-full flex items-center gap-1 px-4 pl-8 py-2 text-xs text-muted-foreground hover:text-primary transition-colors border-b"
+                      >
+                        <Plus className="h-3 w-3" />
+                        Add lesson
+                      </button>
+                    </div>
+                  )}
+                </div>
+              ))}
+
+              {/* Add module */}
+              <div className="p-3 space-y-1.5">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full text-xs"
+                  onClick={addModule}
+                >
+                  <Plus className="h-3 w-3 mr-1" />
+                  Add module
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* RIGHT PANEL — Selected lesson details */}
+        <Card>
+          <CardContent className="pt-6">
+            {selectedLesson ? (
+              <div className="space-y-5">
+                {/* Lesson title */}
+                <div className="space-y-2">
+                  <Label className="text-xs text-muted-foreground">
+                    Lesson Title
+                  </Label>
+                  <Input
+                    value={selectedLesson.title}
+                    onChange={(e) =>
+                      updateLessonField(
+                        selectedModuleIndex,
+                        selectedLessonIndex,
+                        'title',
+                        e.target.value
+                      )
+                    }
+                    className="text-base font-medium"
+                  />
+                </div>
+
+                {/* Lesson description */}
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-xs text-muted-foreground">
+                      Description
+                    </Label>
+                    <span className="text-[10px] text-muted-foreground">
+                      {(selectedLesson.description || '').length}/200
+                    </span>
+                  </div>
+                  <Textarea
+                    value={selectedLesson.description}
+                    onChange={(e) =>
+                      updateLessonField(
+                        selectedModuleIndex,
+                        selectedLessonIndex,
+                        'description',
+                        e.target.value
+                      )
+                    }
+                    rows={3}
+                    className="resize-none text-sm"
+                    placeholder="Brief description of what this lesson covers..."
+                    maxLength={200}
+                  />
+                </div>
+
+                {/* Topics */}
+                <div className="space-y-2">
+                  <Label className="text-xs text-muted-foreground">
+                    Topics
+                  </Label>
+                  <div className="space-y-1.5">
+                    {(selectedLesson.topics || []).map((topic, ti) => (
+                      <div key={ti} className="flex items-center gap-2 group">
+                        <span className="text-xs text-muted-foreground shrink-0">
+                          &bull;
+                        </span>
+                        <Input
+                          value={topic}
+                          onChange={(e) =>
+                            updateLessonTopic(
+                              selectedModuleIndex,
+                              selectedLessonIndex,
+                              ti,
+                              e.target.value
+                            )
+                          }
+                          className="h-8 text-sm"
+                          placeholder="Key topic..."
+                        />
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-6 w-6 shrink-0 opacity-0 group-hover:opacity-100 text-destructive"
+                          onClick={() =>
+                            deleteLessonTopic(
+                              selectedModuleIndex,
+                              selectedLessonIndex,
+                              ti
+                            )
+                          }
+                        >
+                          <X className="h-3 w-3" />
+                        </Button>
+                      </div>
+                    ))}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-xs"
+                      onClick={() =>
+                        addLessonTopic(
+                          selectedModuleIndex,
+                          selectedLessonIndex
+                        )
+                      }
+                    >
+                      <Plus className="h-3 w-3 mr-1" />
+                      Add topic
+                    </Button>
+                  </div>
+                </div>
+
+                {/* Duration */}
+                <div className="space-y-2">
+                  <Label className="text-xs text-muted-foreground">
+                    Estimated Duration (minutes)
+                  </Label>
+                  <Input
+                    type="number"
+                    min={1}
+                    max={60}
+                    value={selectedLesson.estimated_duration_minutes}
+                    onChange={(e) =>
+                      updateLessonField(
+                        selectedModuleIndex,
+                        selectedLessonIndex,
+                        'estimated_duration_minutes',
+                        parseInt(e.target.value) || 10
+                      )
+                    }
+                    className="h-9 w-24"
+                  />
+                </div>
+
+                {/* Delete lesson */}
+                <div className="pt-2 border-t">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-destructive text-xs"
+                    onClick={() =>
+                      deleteLesson(selectedModuleIndex, selectedLessonIndex)
+                    }
+                    disabled={
+                      outline.modules[selectedModuleIndex].lessons.length <= 1
+                    }
+                  >
+                    <Trash2 className="h-3 w-3 mr-1" />
+                    Delete this lesson
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-48 text-sm text-muted-foreground">
+                Select a lesson from the outline to edit its details.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-between">
+        <Button variant="outline" onClick={onBack}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+        <Button onClick={onNext}>
+          Content options
+          <ArrowRight className="h-4 w-4 ml-2" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// Re-exported for the Input label reference
+function Label({
+  className,
+  children,
+  ...props
+}: React.LabelHTMLAttributes<HTMLLabelElement>) {
+  return (
+    <label className={cn('text-sm font-medium', className)} {...props}>
+      {children}
+    </label>
+  );
+}

--- a/src/components/authoring/ai/StepSourceMaterial.tsx
+++ b/src/components/authoring/ai/StepSourceMaterial.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { Card, CardContent } from '@/components/ui/card';
+import { ArrowRight, ChevronDown, Sparkles, Settings2 } from 'lucide-react';
+import { DocumentUploader } from './DocumentUploader';
+import type { DocumentChunk } from '@/types/authoring';
+
+export interface SourceMaterialData {
+  description: string;
+  sourceChunks: DocumentChunk[];
+  language: 'ar' | 'en';
+  industry: string;
+}
+
+interface StepSourceMaterialProps {
+  data: SourceMaterialData;
+  onChange: (data: SourceMaterialData) => void;
+  onNext: () => void;
+  onCancel: () => void;
+  isLoading: boolean;
+}
+
+const INDUSTRIES = [
+  { value: 'general', label: 'General' },
+  { value: 'hr', label: 'Human Resources' },
+  { value: 'compliance', label: 'Compliance & Regulatory' },
+  { value: 'sales', label: 'Sales & Marketing' },
+  { value: 'technical', label: 'Technical & IT' },
+  { value: 'leadership', label: 'Leadership & Management' },
+  { value: 'safety', label: 'Health & Safety' },
+  { value: 'finance', label: 'Finance & Accounting' },
+  { value: 'customer_service', label: 'Customer Service' },
+  { value: 'onboarding', label: 'Employee Onboarding' },
+];
+
+export function StepSourceMaterial({
+  data,
+  onChange,
+  onNext,
+  onCancel,
+  isLoading,
+}: StepSourceMaterialProps) {
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  const handleDocumentExtracted = (chunks: DocumentChunk[]) => {
+    onChange({ ...data, sourceChunks: chunks });
+    // Auto-fill description from first heading if empty
+    if (!data.description.trim() && chunks.length > 0) {
+      const firstHeading = chunks.find((c) => c.type === 'heading');
+      if (firstHeading) {
+        onChange({ ...data, sourceChunks: chunks, description: firstHeading.text });
+      }
+    }
+  };
+
+  const canProceed = data.description.trim().length >= 3;
+
+  return (
+    <div className="space-y-6">
+      {/* Hero section */}
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold flex items-center gap-2">
+          <Sparkles className="h-5 w-5 text-primary" />
+          Let&apos;s build your course together
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Share your vision and source materials, and we&apos;ll create engaging
+          lessons designed for your learners.
+        </p>
+      </div>
+
+      {/* Main input — Course description */}
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="description" className="text-sm font-medium">
+              Describe your course <span className="text-destructive">*</span>
+            </Label>
+            <Textarea
+              id="description"
+              placeholder="e.g., A course on B2B sales activities and strategies for mid-level professionals..."
+              value={data.description}
+              onChange={(e) =>
+                onChange({ ...data, description: e.target.value })
+              }
+              rows={4}
+              className="resize-none"
+            />
+            <p className="text-xs text-muted-foreground">
+              A few words is enough to get started, but add as much context as
+              you&apos;d like.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Source document (optional) */}
+      <Card>
+        <CardContent className="pt-6 space-y-2">
+          <Label className="text-sm font-medium">
+            Source materials (optional)
+          </Label>
+          <DocumentUploader onExtracted={handleDocumentExtracted} />
+          {data.sourceChunks.length > 0 && (
+            <p className="text-xs text-muted-foreground">
+              {data.sourceChunks.length} sections extracted (
+              {data.sourceChunks
+                .reduce((s, c) => s + c.text.length, 0)
+                .toLocaleString()}{' '}
+              characters)
+            </p>
+          )}
+          <p className="text-xs text-muted-foreground">
+            Add documents, slides, or files. AI will restructure important
+            concepts into an effective course designed for your learners.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Advanced options (collapsed) */}
+      <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
+        <CollapsibleTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-between text-muted-foreground hover:text-foreground"
+          >
+            <span className="flex items-center gap-1.5">
+              <Settings2 className="h-4 w-4" />
+              Advanced options
+            </span>
+            <ChevronDown
+              className={`h-4 w-4 transition-transform ${
+                advancedOpen ? 'rotate-180' : ''
+              }`}
+            />
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <Card className="mt-2">
+            <CardContent className="pt-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label className="text-xs">Language</Label>
+                  <Select
+                    value={data.language}
+                    onValueChange={(v) =>
+                      onChange({ ...data, language: v as 'ar' | 'en' })
+                    }
+                  >
+                    <SelectTrigger className="h-9">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="ar">Arabic (MSA)</SelectItem>
+                      <SelectItem value="en">English</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-xs">Industry</Label>
+                  <Select
+                    value={data.industry}
+                    onValueChange={(v) => onChange({ ...data, industry: v })}
+                  >
+                    <SelectTrigger className="h-9">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {INDUSTRIES.map((ind) => (
+                        <SelectItem key={ind.value} value={ind.value}>
+                          {ind.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </CollapsibleContent>
+      </Collapsible>
+
+      {/* Actions */}
+      <div className="flex justify-between">
+        <Button variant="outline" onClick={onCancel} disabled={isLoading}>
+          Cancel
+        </Button>
+        <Button onClick={onNext} disabled={!canProceed || isLoading}>
+          {isLoading ? (
+            <>
+              <span className="h-4 w-4 mr-2 animate-spin rounded-full border-2 border-current border-t-transparent" />
+              Generating course details...
+            </>
+          ) : (
+            <>
+              Generate course details
+              <ArrowRight className="h-4 w-4 ml-2" />
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -1,6 +1,56 @@
 // src/lib/ai/prompts.ts -- Phase 3: AI Course Generation
 
 // ============================================================
+// COURSE DETAILS GENERATION PROMPT (Step 2 — from description)
+// ============================================================
+export const COURSE_DETAILS_SYSTEM_PROMPT = `You are an expert instructional designer specializing in Arabic and English e-learning courses for the MENA region.
+
+Your task is to analyze a course description (and optional source material) and generate comprehensive course details.
+
+RULES:
+1. Generate a clear, specific course topic from the description
+2. Suggest an appropriate tone based on the subject matter
+3. Identify the most likely target audience
+4. Write a concise course goal (1-2 sentences)
+5. Determine the appropriate difficulty level
+6. Suggest a course length based on topic complexity:
+   - "micro": Very focused topic, 1 module, < 10 minutes
+   - "short": Focused topic, 2 modules, < 1 hour
+   - "standard": Moderate topic, 4 modules, 1-3 hours
+   - "extended": Comprehensive topic, 6+ modules, 3+ hours
+7. Generate 3-6 learning objectives using action verbs (Bloom's Taxonomy)
+8. Learning objectives should start with verbs like: Identify, Explain, Apply, Analyze, Evaluate, Create, Develop, Implement, Compare, Design
+
+LANGUAGE RULES:
+- If language is "ar": Write ALL content in Modern Standard Arabic (MSA)
+- If language is "en": Write in clear, professional English
+
+OUTPUT: Return ONLY valid JSON. No markdown, no explanations.`;
+
+export const COURSE_DETAILS_USER_PROMPT = (params: {
+  description: string;
+  language: string;
+  sourceChunks?: string;
+  industry?: string;
+}) => `Analyze this course description and generate course details:
+
+Description: ${params.description}
+Language: ${params.language === 'ar' ? 'Arabic (MSA)' : 'English'}
+${params.industry ? `Industry/Domain: ${params.industry}` : ''}
+${params.sourceChunks ? `\nSource Material:\n${params.sourceChunks}` : ''}
+
+Return a JSON object with this exact structure:
+{
+  "topic": "string (clear, specific course topic)",
+  "tone": "string (e.g., Practical, confident, motivating)",
+  "audience": "string (specific target audience description)",
+  "goals": "string (1-2 sentence course goal)",
+  "difficulty": "beginner" | "intermediate" | "advanced",
+  "suggested_length": "micro" | "short" | "standard" | "extended",
+  "learning_objectives": ["string (action verb + measurable outcome)", ...]
+}`;
+
+// ============================================================
 // OUTLINE GENERATION PROMPT
 // ============================================================
 export const OUTLINE_SYSTEM_PROMPT = `You are an expert instructional designer specializing in Arabic and English e-learning courses for the MENA region.
@@ -81,7 +131,8 @@ Return a JSON object with this exact structure:
           "description": "string",
           "order": 0,
           "suggested_blocks": ["cover", "text", "image", "accordion", "tabs", "multiple_choice"],
-          "estimated_duration_minutes": number
+          "estimated_duration_minutes": number,
+          "topics": ["string (key topic 1)", "string (key topic 2)", "string (key topic 3)"]
         }
       ]
     }

--- a/src/types/authoring.ts
+++ b/src/types/authoring.ts
@@ -529,6 +529,50 @@ export interface CourseTheme {
 // AI GENERATION TYPES
 // ============================================================
 
+export type CourseLength = 'micro' | 'short' | 'standard' | 'extended';
+
+/** AI-generated course details — produced from just a description in Step 2 */
+export interface CourseDetails {
+  topic: string;
+  tone: string;
+  audience: string;
+  goals: string;
+  difficulty: 'beginner' | 'intermediate' | 'advanced';
+  suggested_length: CourseLength;
+  learning_objectives: string[];
+}
+
+/** Content generation options selected in Step 5 */
+export interface ContentOptions {
+  content_format: 'interactive' | 'text_only';
+  generate_images: boolean;
+  assessment_density: 'per_lesson' | 'per_module' | 'none';
+}
+
+/** Course length → module/lesson mapping */
+export const COURSE_LENGTH_CONFIG: Record<CourseLength, { modules: number; lessonsPerModule: number; label: string; description: string; duration: string }> = {
+  micro: { modules: 1, lessonsPerModule: 2, label: 'Micro', description: '1 module, 2 lessons', duration: '< 10 min' },
+  short: { modules: 2, lessonsPerModule: 3, label: 'Short', description: '2 modules, ~6 lessons', duration: '< 1 hour' },
+  standard: { modules: 4, lessonsPerModule: 3, label: 'Standard', description: '4 modules, ~12 lessons', duration: '1-3 hours' },
+  extended: { modules: 6, lessonsPerModule: 4, label: 'Extended', description: '6+ modules, ~24 lessons', duration: '3+ hours' },
+};
+
+export interface CourseOutlineLesson {
+  title: string;
+  description: string;
+  order: number;
+  suggested_blocks: BlockType[];
+  estimated_duration_minutes: number;
+  topics: string[];                     // Key topics covered in this lesson
+}
+
+export interface CourseOutlineModule {
+  title: string;
+  description: string;
+  order: number;
+  lessons: CourseOutlineLesson[];
+}
+
 export interface CourseOutline {
   title: string;
   description: string;
@@ -536,18 +580,7 @@ export interface CourseOutline {
   difficulty: 'beginner' | 'intermediate' | 'advanced';
   language: 'ar' | 'en';
   estimated_duration_minutes: number;
-  modules: {
-    title: string;
-    description: string;
-    order: number;
-    lessons: {
-      title: string;
-      description: string;
-      order: number;
-      suggested_blocks: BlockType[];    // AI suggests which block types to use
-      estimated_duration_minutes: number;
-    }[];
-  }[];
+  modules: CourseOutlineModule[];
   learning_outcomes: string[];
 }
 


### PR DESCRIPTION
Redesigns the AI Course Wizard to match and exceed Rise Articulate's "Create course with AI" flow, transforming from a 3-step manual form into a 6-step guided pipeline:

Step 1 (StepSourceMaterial): Simplified input — just describe your course + optional document upload + optional URL. Advanced options (language, industry) collapsed by default. Down from 7 required fields to 1.

Step 2 (StepCourseDetails): NEW — AI auto-generates course topic, tone, audience, goals, difficulty, and suggested length from just the description. Visual course length picker cards (Micro/Short/ Standard/Extended) replace module/lesson count dropdowns. "Edit with AI" dropdown on course information section.

Step 3 (StepLearningObjectives): NEW — Dedicated draggable learning objectives editor with @dnd-kit sortable, inline editing, add/delete, and "Edit with AI" dropdown. Previously read-only bullets.

Step 4 (StepOutlineEditor): REDESIGNED — Split-panel layout with left sidebar (module/lesson tree navigation) and right panel (lesson details: title, description with char count, topics bullet list, duration). Replaces single-column card layout.

Step 5 (StepContentOptions): NEW — Pre-generation configuration: content format (interactive vs text-only), AI image toggle with cost estimate, assessment density (per lesson/module/none). Rise has 2 options; we have 3 categories.

Step 6 (StepGeneration): ENHANCED — Auto-starts generation (no manual button), adds estimated time remaining calculation, current lesson indicator, and visual state transitions per lesson card.

New API route: POST /api/ai/generate-course-details — Takes a course description and generates all details using Claude. Includes usage logging and cost tracking.

New types: CourseDetails, ContentOptions, CourseLength, CourseOutlineLesson (with topics[]), CourseOutlineModule, COURSE_LENGTH_CONFIG constant.

New prompt: COURSE_DETAILS_SYSTEM_PROMPT + COURSE_DETAILS_USER_PROMPT in prompts.ts. Outline prompt updated to include topics[] per lesson.

Zero TypeScript errors. No changes to existing editor, player, store, or other API routes.

https://claude.ai/code/session_01R5WhtkpDFAraV5jCFAPRoU