### PR TITLE
feat: modernize authoring UI — floating toolbars, inline insertion, s…

### DIFF
--- a/src/components/authoring/BlockToolbar.tsx
+++ b/src/components/authoring/BlockToolbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import {
   Type,
   Image,
@@ -34,6 +34,7 @@ import {
   MessageSquare,
   SquareMousePointer,
   ArrowDown,
+  Search,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -43,6 +44,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { BlockType } from '@/types/authoring';
+import { cn } from '@/lib/utils';
 
 interface BlockToolbarProps {
   onInsertBlock: (blockType: BlockType) => void;
@@ -51,8 +53,10 @@ interface BlockToolbarProps {
 interface BlockOption {
   type: BlockType;
   label: string;
+  description: string;
   icon: LucideIcon;
   phase1: boolean;
+  keywords: string[];
 }
 
 interface BlockCategory {
@@ -64,58 +68,87 @@ const BLOCK_CATEGORIES: BlockCategory[] = [
   {
     name: 'Content',
     blocks: [
-      { type: BlockType.TEXT, label: 'Text', icon: Type, phase1: true },
-      { type: BlockType.IMAGE, label: 'Image', icon: Image, phase1: true },
-      { type: BlockType.VIDEO, label: 'Video', icon: Video, phase1: true },
-      { type: BlockType.DIVIDER, label: 'Divider', icon: Minus, phase1: true },
-      { type: BlockType.COVER, label: 'Cover', icon: Frame, phase1: true },
-      { type: BlockType.AUDIO, label: 'Audio', icon: Headphones, phase1: true },
-      { type: BlockType.CODE, label: 'Code', icon: Code, phase1: true },
-      { type: BlockType.EMBED, label: 'Embed', icon: ExternalLink, phase1: true },
-      { type: BlockType.QUOTE, label: 'Quote', icon: Quote, phase1: true },
-      { type: BlockType.LIST, label: 'List', icon: List, phase1: true },
-      { type: BlockType.TABLE, label: 'Table', icon: Table2, phase1: true },
-      { type: BlockType.GALLERY, label: 'Gallery', icon: GalleryHorizontal, phase1: true },
-      { type: BlockType.CHART, label: 'Chart', icon: BarChart3, phase1: true },
-      { type: BlockType.CALLOUT, label: 'Callout', icon: MessageSquareWarning, phase1: true },
-      { type: BlockType.STATEMENT, label: 'Statement', icon: MessageSquare, phase1: true },
+      { type: BlockType.TEXT, label: 'Text', description: 'Rich text with formatting', icon: Type, phase1: true, keywords: ['paragraph', 'write', 'rich', 'heading'] },
+      { type: BlockType.IMAGE, label: 'Image', description: 'Upload or embed an image', icon: Image, phase1: true, keywords: ['photo', 'picture', 'upload', 'media'] },
+      { type: BlockType.VIDEO, label: 'Video', description: 'Embed a video lesson', icon: Video, phase1: true, keywords: ['media', 'stream', 'bunny', 'youtube'] },
+      { type: BlockType.DIVIDER, label: 'Divider', description: 'Visual separator between sections', icon: Minus, phase1: true, keywords: ['separator', 'line', 'break', 'space'] },
+      { type: BlockType.COVER, label: 'Cover', description: 'Full-width hero banner', icon: Frame, phase1: true, keywords: ['banner', 'hero', 'header', 'title'] },
+      { type: BlockType.AUDIO, label: 'Audio', description: 'Audio clip or podcast', icon: Headphones, phase1: true, keywords: ['music', 'sound', 'podcast', 'mp3'] },
+      { type: BlockType.CODE, label: 'Code', description: 'Syntax-highlighted code block', icon: Code, phase1: true, keywords: ['snippet', 'programming', 'developer'] },
+      { type: BlockType.EMBED, label: 'Embed', description: 'External content via iframe', icon: ExternalLink, phase1: true, keywords: ['iframe', 'external', 'website', 'url'] },
+      { type: BlockType.QUOTE, label: 'Quote', description: 'Highlighted quotation', icon: Quote, phase1: true, keywords: ['citation', 'blockquote', 'testimonial'] },
+      { type: BlockType.LIST, label: 'List', description: 'Bullet, numbered, or icon list', icon: List, phase1: true, keywords: ['bullet', 'numbered', 'items', 'checklist'] },
+      { type: BlockType.TABLE, label: 'Table', description: 'Data in rows and columns', icon: Table2, phase1: true, keywords: ['grid', 'spreadsheet', 'data', 'rows'] },
+      { type: BlockType.GALLERY, label: 'Gallery', description: 'Image carousel or grid', icon: GalleryHorizontal, phase1: true, keywords: ['carousel', 'slideshow', 'images'] },
+      { type: BlockType.CHART, label: 'Chart', description: 'Data visualization chart', icon: BarChart3, phase1: true, keywords: ['graph', 'bar', 'pie', 'visualization'] },
+      { type: BlockType.CALLOUT, label: 'Callout', description: 'Info, warning, or tip box', icon: MessageSquareWarning, phase1: true, keywords: ['alert', 'notice', 'tip', 'warning', 'info'] },
+      { type: BlockType.STATEMENT, label: 'Statement', description: 'Bold emphasized message', icon: MessageSquare, phase1: true, keywords: ['highlight', 'emphasis', 'key point'] },
     ],
   },
   {
     name: 'Interactive',
     blocks: [
-      { type: BlockType.ACCORDION, label: 'Accordion', icon: ChevronDown, phase1: true },
-      { type: BlockType.TABS, label: 'Tabs', icon: Columns, phase1: true },
-      { type: BlockType.FLASHCARD, label: 'Flashcard', icon: Layers, phase1: true },
-      { type: BlockType.LABELED_GRAPHIC, label: 'Labeled Graphic', icon: Tag, phase1: true },
-      { type: BlockType.PROCESS, label: 'Process', icon: GitBranch, phase1: true },
-      { type: BlockType.TIMELINE, label: 'Timeline', icon: Clock, phase1: true },
-      { type: BlockType.HOTSPOT, label: 'Hotspot', icon: MousePointerClick, phase1: true },
-      { type: BlockType.SCENARIO, label: 'Scenario', icon: Route, phase1: true },
+      { type: BlockType.ACCORDION, label: 'Accordion', description: 'Expandable content sections', icon: ChevronDown, phase1: true, keywords: ['collapse', 'expand', 'faq', 'toggle'] },
+      { type: BlockType.TABS, label: 'Tabs', description: 'Tabbed content panels', icon: Columns, phase1: true, keywords: ['panel', 'switch', 'sections'] },
+      { type: BlockType.FLASHCARD, label: 'Flashcard', description: 'Flip cards for memorization', icon: Layers, phase1: true, keywords: ['flip', 'cards', 'study', 'memory'] },
+      { type: BlockType.LABELED_GRAPHIC, label: 'Labeled Graphic', description: 'Image with labeled markers', icon: Tag, phase1: true, keywords: ['annotate', 'diagram', 'markers', 'labels'] },
+      { type: BlockType.PROCESS, label: 'Process', description: 'Step-by-step flow', icon: GitBranch, phase1: true, keywords: ['steps', 'workflow', 'procedure', 'flow'] },
+      { type: BlockType.TIMELINE, label: 'Timeline', description: 'Chronological sequence', icon: Clock, phase1: true, keywords: ['history', 'dates', 'chronology', 'events'] },
+      { type: BlockType.HOTSPOT, label: 'Hotspot', description: 'Clickable regions on an image', icon: MousePointerClick, phase1: true, keywords: ['click', 'regions', 'interactive image'] },
+      { type: BlockType.SCENARIO, label: 'Scenario', description: 'Branching decision scenario', icon: Route, phase1: true, keywords: ['branch', 'decision', 'choose', 'path'] },
     ],
   },
   {
     name: 'Assessment',
     blocks: [
-      { type: BlockType.MULTIPLE_CHOICE, label: 'Multiple Choice', icon: CircleDot, phase1: true },
-      { type: BlockType.TRUE_FALSE, label: 'True / False', icon: ToggleLeft, phase1: true },
-      { type: BlockType.MULTIPLE_RESPONSE, label: 'Multiple Response', icon: CheckSquare, phase1: true },
-      { type: BlockType.FILL_IN_BLANK, label: 'Fill in Blank', icon: TextCursorInput, phase1: true },
-      { type: BlockType.MATCHING, label: 'Matching', icon: ArrowLeftRight, phase1: true },
-      { type: BlockType.SORTING, label: 'Sorting', icon: ArrowUpDown, phase1: true },
+      { type: BlockType.MULTIPLE_CHOICE, label: 'Multiple Choice', description: 'Single-answer question', icon: CircleDot, phase1: true, keywords: ['quiz', 'question', 'mcq', 'test'] },
+      { type: BlockType.TRUE_FALSE, label: 'True / False', description: 'Binary answer question', icon: ToggleLeft, phase1: true, keywords: ['quiz', 'boolean', 'yes no'] },
+      { type: BlockType.MULTIPLE_RESPONSE, label: 'Multiple Response', description: 'Multi-answer selection', icon: CheckSquare, phase1: true, keywords: ['quiz', 'multi', 'select all'] },
+      { type: BlockType.FILL_IN_BLANK, label: 'Fill in Blank', description: 'Type the answer', icon: TextCursorInput, phase1: true, keywords: ['quiz', 'input', 'type', 'blank'] },
+      { type: BlockType.MATCHING, label: 'Matching', description: 'Pair items together', icon: ArrowLeftRight, phase1: true, keywords: ['quiz', 'pair', 'connect', 'match'] },
+      { type: BlockType.SORTING, label: 'Sorting', description: 'Arrange items in order', icon: ArrowUpDown, phase1: true, keywords: ['quiz', 'order', 'rank', 'sequence'] },
     ],
   },
   {
     name: 'Navigation',
     blocks: [
-      { type: BlockType.BUTTON, label: 'Button', icon: SquareMousePointer, phase1: true },
-      { type: BlockType.CONTINUE, label: 'Continue', icon: ArrowDown, phase1: true },
+      { type: BlockType.BUTTON, label: 'Button', description: 'Clickable action button', icon: SquareMousePointer, phase1: true, keywords: ['link', 'cta', 'action', 'click'] },
+      { type: BlockType.CONTINUE, label: 'Continue', description: 'Lesson progress gate', icon: ArrowDown, phase1: true, keywords: ['gate', 'progress', 'lock', 'next'] },
     ],
   },
 ];
 
+// Flatten all blocks for search
+const ALL_BLOCKS = BLOCK_CATEGORIES.flatMap((c) =>
+  c.blocks.map((b) => ({ ...b, category: c.name })),
+);
+
 export function BlockToolbar({ onInsertBlock }: BlockToolbarProps) {
   const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus search when popover opens
+  useEffect(() => {
+    if (open) {
+      setSearch('');
+      // Small delay for popover animation
+      const t = setTimeout(() => searchRef.current?.focus(), 50);
+      return () => clearTimeout(t);
+    }
+  }, [open]);
+
+  const filteredResults = useMemo(() => {
+    if (!search.trim()) return null;
+    const q = search.toLowerCase().trim();
+    return ALL_BLOCKS.filter(
+      (b) =>
+        b.label.toLowerCase().includes(q) ||
+        b.description.toLowerCase().includes(q) ||
+        b.keywords.some((k) => k.includes(q)) ||
+        b.category.toLowerCase().includes(q),
+    );
+  }, [search]);
 
   function handleSelect(block: BlockOption) {
     if (!block.phase1) return;
@@ -123,57 +156,137 @@ export function BlockToolbar({ onInsertBlock }: BlockToolbarProps) {
     setOpen(false);
   }
 
+  const showSearch = filteredResults !== null;
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-1.5">
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-1.5 border-dashed hover:border-primary/40 hover:bg-primary/5 hover:text-primary transition-colors"
+        >
           <Plus className="h-4 w-4" />
           Add Block
         </Button>
       </PopoverTrigger>
       <PopoverContent
         align="start"
-        className="w-[420px] max-h-[480px] overflow-y-auto p-0"
+        className="w-[440px] max-h-[520px] overflow-hidden p-0"
       >
-        <div className="p-3 space-y-4">
-          {BLOCK_CATEGORIES.map((category) => (
-            <div key={category.name}>
-              <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2 px-1">
-                {category.name}
-              </h4>
-              <div className="grid grid-cols-3 gap-1">
-                {category.blocks.map((block) => {
-                  const Icon = block.icon;
-                  const disabled = !block.phase1;
+        {/* Search input */}
+        <div className="sticky top-0 z-10 border-b border-border/60 bg-background p-2.5">
+          <div className="relative">
+            <Search className="absolute start-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+            <input
+              ref={searchRef}
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search blocks..."
+              className="w-full rounded-md border border-border/60 bg-muted/30 py-1.5 ps-8 pe-3 text-sm placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/40 transition-colors"
+            />
+          </div>
+        </div>
 
-                  return (
-                    <button
-                      key={block.type}
-                      type="button"
-                      disabled={disabled}
-                      onClick={() => handleSelect(block)}
-                      className={
-                        'relative flex flex-col items-center gap-1.5 rounded-md px-2 py-3 text-xs transition-colors ' +
-                        (disabled
-                          ? 'cursor-not-allowed opacity-40'
-                          : 'hover:bg-muted cursor-pointer')
-                      }
-                    >
-                      <Icon className="h-5 w-5 shrink-0" />
-                      <span className="leading-tight text-center">
-                        {block.label}
-                      </span>
-                      {disabled && (
-                        <span className="absolute -top-0.5 -end-0.5 rounded bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground">
-                          Soon
-                        </span>
-                      )}
-                    </button>
-                  );
-                })}
-              </div>
+        {/* Results area */}
+        <div className="overflow-y-auto max-h-[440px]">
+          {showSearch ? (
+            /* ── Search results (list view) ── */
+            <div className="p-2">
+              {filteredResults.length === 0 ? (
+                <div className="flex flex-col items-center py-8 text-center">
+                  <Search className="h-8 w-8 text-muted-foreground/30 mb-2" />
+                  <p className="text-sm text-muted-foreground">
+                    No blocks match &ldquo;{search}&rdquo;
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-0.5">
+                  {filteredResults.map((block) => {
+                    const Icon = block.icon;
+                    return (
+                      <button
+                        key={block.type}
+                        type="button"
+                        onClick={() => handleSelect(block)}
+                        className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-start transition-colors hover:bg-muted group"
+                      >
+                        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted/60 border border-border/40 group-hover:bg-primary/10 group-hover:border-primary/20 group-hover:text-primary transition-colors">
+                          <Icon className="h-4 w-4" />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className="text-sm font-medium text-foreground">
+                              {block.label}
+                            </span>
+                            <span className="text-[10px] text-muted-foreground/70 uppercase tracking-wider">
+                              {block.category}
+                            </span>
+                          </div>
+                          <p className="text-xs text-muted-foreground truncate">
+                            {block.description}
+                          </p>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
             </div>
-          ))}
+          ) : (
+            /* ── Category grid view ── */
+            <div className="p-3 space-y-4">
+              {BLOCK_CATEGORIES.map((category) => (
+                <div key={category.name}>
+                  <h4 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2 px-1">
+                    {category.name}
+                  </h4>
+                  <div className="grid grid-cols-3 gap-1">
+                    {category.blocks.map((block) => {
+                      const Icon = block.icon;
+                      const disabled = !block.phase1;
+
+                      return (
+                        <button
+                          key={block.type}
+                          type="button"
+                          disabled={disabled}
+                          onClick={() => handleSelect(block)}
+                          className={cn(
+                            'group relative flex flex-col items-center gap-1.5 rounded-lg px-2 py-3 text-xs transition-all',
+                            disabled
+                              ? 'cursor-not-allowed opacity-40'
+                              : 'hover:bg-primary/5 hover:text-primary cursor-pointer',
+                          )}
+                          title={block.description}
+                        >
+                          <div
+                            className={cn(
+                              'flex h-9 w-9 items-center justify-center rounded-lg transition-colors',
+                              disabled
+                                ? 'bg-muted/40'
+                                : 'bg-muted/60 border border-border/40 group-hover:bg-primary/10 group-hover:border-primary/20',
+                            )}
+                          >
+                            <Icon className="h-4 w-4 shrink-0" />
+                          </div>
+                          <span className="leading-tight text-center">
+                            {block.label}
+                          </span>
+                          {disabled && (
+                            <span className="absolute -top-0.5 -end-0.5 rounded bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground">
+                              Soon
+                            </span>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </PopoverContent>
     </Popover>

--- a/src/components/authoring/BlockWrapper.tsx
+++ b/src/components/authoring/BlockWrapper.tsx
@@ -3,25 +3,58 @@
 import React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, Trash2, Copy } from 'lucide-react';
+import {
+  GripVertical,
+  Trash2,
+  Copy,
+  ChevronUp,
+  ChevronDown,
+  MoreHorizontal,
+  Eye,
+  EyeOff,
+  Lock,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
 interface BlockWrapperProps {
   id: string;
   isSelected: boolean;
+  blockType?: string;
+  blockIndex?: number;
+  totalBlocks?: number;
   onSelect: () => void;
   onDelete: () => void;
   onDuplicate: () => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
   children: React.ReactNode;
 }
 
 export function BlockWrapper({
   id,
   isSelected,
+  blockType,
+  blockIndex,
+  totalBlocks,
   onSelect,
   onDelete,
   onDuplicate,
+  onMoveUp,
+  onMoveDown,
   children,
 }: BlockWrapperProps) {
   const {
@@ -40,73 +73,193 @@ export function BlockWrapper({
     zIndex: isDragging ? 50 : undefined,
   };
 
+  const canMoveUp = blockIndex !== undefined && blockIndex > 0;
+  const canMoveDown =
+    blockIndex !== undefined &&
+    totalBlocks !== undefined &&
+    blockIndex < totalBlocks - 1;
+
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className={cn(
-        'group relative rounded-lg border bg-card transition-colors',
-        isSelected
-          ? 'border-primary ring-2 ring-primary/20'
-          : 'border-border hover:border-muted-foreground/30',
-        isDragging && 'opacity-50 shadow-lg',
-      )}
-      onClick={(e) => {
-        // Prevent selection when clicking action buttons
-        if ((e.target as HTMLElement).closest('[data-block-action]')) return;
-        onSelect();
-      }}
-    >
-      {/* Drag handle - visible on hover or when selected */}
+    <TooltipProvider delayDuration={400}>
       <div
-        ref={setActivatorNodeRef}
-        {...attributes}
-        {...listeners}
+        ref={setNodeRef}
+        style={style}
         className={cn(
-          'absolute -start-3 top-1/2 -translate-y-1/2 flex h-8 w-6 cursor-grab items-center justify-center rounded-md border bg-background text-muted-foreground shadow-sm transition-opacity active:cursor-grabbing',
-          isSelected || isDragging
-            ? 'opacity-100'
-            : 'opacity-0 group-hover:opacity-100',
+          'group/block relative rounded-xl border bg-card transition-all duration-200',
+          isSelected
+            ? 'border-primary/60 shadow-[0_0_0_1px_rgba(var(--primary-rgb,59,130,246),0.15)] ring-[3px] ring-primary/10'
+            : 'border-border/60 hover:border-border hover:shadow-sm',
+          isDragging && 'opacity-40 shadow-2xl scale-[1.02] rotate-[0.5deg]',
         )}
-        aria-label="Drag to reorder block"
+        onClick={(e) => {
+          if ((e.target as HTMLElement).closest('[data-block-action]')) return;
+          onSelect();
+        }}
       >
-        <GripVertical className="h-4 w-4" />
-      </div>
+        {/* Block type label - shows on hover */}
+        {blockType && (
+          <div
+            className={cn(
+              'absolute -top-2.5 start-3 z-10 rounded-md bg-muted/90 backdrop-blur-sm px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground border border-border/50 transition-all duration-200',
+              isSelected
+                ? 'opacity-100 bg-primary/10 text-primary border-primary/20'
+                : 'opacity-0 group-hover/block:opacity-100',
+            )}
+          >
+            {blockType.replace(/_/g, ' ')}
+          </div>
+        )}
 
-      {/* Action buttons - shown when selected */}
-      {isSelected && (
-        <div className="absolute -top-3 end-2 z-10 flex items-center gap-1">
-          <Button
-            data-block-action
-            variant="outline"
-            size="sm"
-            className="h-7 w-7 p-0 bg-background shadow-sm"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDuplicate();
-            }}
-            aria-label="Duplicate block"
-          >
-            <Copy className="h-3.5 w-3.5" />
-          </Button>
-          <Button
-            data-block-action
-            variant="outline"
-            size="sm"
-            className="h-7 w-7 p-0 bg-background text-destructive hover:bg-destructive hover:text-destructive-foreground shadow-sm"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete();
-            }}
-            aria-label="Delete block"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-          </Button>
+        {/* Drag handle - left side pill */}
+        <div
+          ref={setActivatorNodeRef}
+          {...attributes}
+          {...listeners}
+          className={cn(
+            'absolute -start-3.5 top-1/2 -translate-y-1/2 flex h-10 w-7 cursor-grab items-center justify-center rounded-lg border bg-background text-muted-foreground shadow-sm transition-all duration-200 hover:shadow-md hover:text-foreground hover:border-primary/30 active:cursor-grabbing active:scale-95',
+            isSelected || isDragging
+              ? 'opacity-100 border-primary/20'
+              : 'opacity-0 group-hover/block:opacity-100',
+          )}
+          aria-label="Drag to reorder block"
+        >
+          <GripVertical className="h-4 w-4" />
         </div>
-      )}
 
-      {/* Block content */}
-      <div className="p-4">{children}</div>
-    </div>
+        {/* Floating action toolbar - shown when selected */}
+        {isSelected && (
+          <div className="absolute -top-4 end-3 z-20 flex items-center gap-0.5 rounded-lg border border-border/80 bg-background/95 backdrop-blur-sm px-1 py-0.5 shadow-lg">
+            {/* Move Up */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  data-block-action
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onMoveUp?.();
+                  }}
+                  disabled={!canMoveUp}
+                >
+                  <ChevronUp className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="text-xs">
+                Move up
+              </TooltipContent>
+            </Tooltip>
+
+            {/* Move Down */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  data-block-action
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onMoveDown?.();
+                  }}
+                  disabled={!canMoveDown}
+                >
+                  <ChevronDown className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="text-xs">
+                Move down
+              </TooltipContent>
+            </Tooltip>
+
+            {/* Divider */}
+            <div className="mx-0.5 h-4 w-px bg-border" />
+
+            {/* Duplicate */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  data-block-action
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDuplicate();
+                  }}
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="text-xs">
+                Duplicate
+              </TooltipContent>
+            </Tooltip>
+
+            {/* Delete */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  data-block-action
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0 text-destructive/70 hover:text-destructive hover:bg-destructive/10"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete();
+                  }}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="text-xs">
+                Delete
+              </TooltipContent>
+            </Tooltip>
+
+            {/* More menu */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  data-block-action
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <MoreHorizontal className="h-3.5 w-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-44">
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDuplicate();
+                  }}
+                >
+                  <Copy className="mr-2 h-3.5 w-3.5" />
+                  Duplicate Block
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete();
+                  }}
+                >
+                  <Trash2 className="mr-2 h-3.5 w-3.5" />
+                  Delete Block
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )}
+
+        {/* Block content */}
+        <div className="p-4">{children}</div>
+      </div>
+    </TooltipProvider>
   );
 }

--- a/src/components/authoring/EditorCanvas.tsx
+++ b/src/components/authoring/EditorCanvas.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   DndContext,
   closestCenter,
@@ -15,11 +15,65 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { Plus } from 'lucide-react';
+import { Plus, Sparkles } from 'lucide-react';
 import { useEditorStore } from '@/stores/editor.store';
 import { BlockEditor } from '@/components/authoring/blocks';
 import { BlockWrapper } from './BlockWrapper';
-import { Button } from '@/components/ui/button';
+import { BlockToolbar } from './BlockToolbar';
+import { BlockType, type Block } from '@/types/authoring';
+import { v4 as uuidv4 } from 'uuid';
+import { cn } from '@/lib/utils';
+
+function createDefaultBlock(type: BlockType): Block {
+  const now = new Date().toISOString();
+  const base = {
+    id: uuidv4(),
+    type,
+    order: 0,
+    visible: true,
+    locked: false,
+    metadata: {
+      created_at: now,
+      updated_at: now,
+      created_by: 'human' as const,
+    },
+  };
+
+  switch (type) {
+    case BlockType.TEXT:
+      return { ...base, type, data: { content: '', alignment: 'start', direction: 'auto' } };
+    case BlockType.IMAGE:
+      return { ...base, type, data: { src: '', alt: '', caption: '', width: 'full', alignment: 'center' } };
+    case BlockType.VIDEO:
+      return { ...base, type, data: { bunny_video_id: '', bunny_library_id: '', title: '', duration_seconds: 0, thumbnail_url: '', captions: [], chapters: [], completion_criteria: 'watch_75', allow_skip: false, autoplay: false } };
+    case BlockType.DIVIDER:
+      return { ...base, type, data: { style: 'line', spacing: 'medium' } };
+    case BlockType.QUOTE:
+      return { ...base, type, data: { text: '', attribution: '', style: 'default' } };
+    case BlockType.LIST:
+      return { ...base, type, data: { items: [{ id: uuidv4(), text: '' }], style: 'bullet', columns: 1 } };
+    case BlockType.CODE:
+      return { ...base, type, data: { code: '', language: 'javascript', show_line_numbers: true, caption: '' } };
+    case BlockType.ACCORDION:
+      return { ...base, type, data: { items: [{ id: uuidv4(), title: 'Section 1', content: '' }], allow_multiple_open: false, start_expanded: false } };
+    case BlockType.CALLOUT:
+      return { ...base, type, data: { variant: 'info', title: '', content: '', collapsible: false } };
+    case BlockType.STATEMENT:
+      return { ...base, type, data: { text: '', style: 'bold', alignment: 'center', accent_color: '' } };
+    case BlockType.BUTTON:
+      return { ...base, type, data: { buttons: [{ id: uuidv4(), label: 'Click me', action: 'link', url: '', style: 'primary' }], alignment: 'center', layout: 'inline' } };
+    case BlockType.CONTINUE:
+      return { ...base, type, data: { label: 'Continue', completion_type: 'none' } };
+    case BlockType.COVER:
+      return { ...base, type, data: { background_image: '', title: '', overlay_color: '#000000AA', text_alignment: 'center', height: 'medium' } };
+    case BlockType.MULTIPLE_CHOICE:
+      return { ...base, type, data: { question: '', options: [{ id: uuidv4(), text: '', is_correct: false }], explanation: '', allow_retry: true, shuffle_options: false, points: 1 } };
+    case BlockType.TRUE_FALSE:
+      return { ...base, type, data: { statement: '', correct_answer: true, explanation_true: '', explanation_false: '', points: 1 } };
+    default:
+      return { ...base, data: {} } as Block;
+  }
+}
 
 export function EditorCanvas() {
   const selectedModuleId = useEditorStore((s) => s.selectedModuleId);
@@ -32,6 +86,7 @@ export function EditorCanvas() {
   const deleteBlock = useEditorStore((s) => s.deleteBlock);
   const duplicateBlock = useEditorStore((s) => s.duplicateBlock);
   const selectBlock = useEditorStore((s) => s.selectBlock);
+  const addBlock = useEditorStore((s) => s.addBlock);
 
   const undo = useEditorStore((s) => s.undo);
   const redo = useEditorStore((s) => s.redo);
@@ -39,13 +94,15 @@ export function EditorCanvas() {
   const currentModule = getCurrentModule();
   const currentLesson = getCurrentLesson();
 
+  // Track which inline inserter is open
+  const [insertAfterIndex, setInsertAfterIndex] = useState<number | null>(null);
+
   // Undo/Redo keyboard shortcuts (Ctrl+Z / Ctrl+Shift+Z)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const isCtrlOrCmd = e.ctrlKey || e.metaKey;
       if (!isCtrlOrCmd) return;
 
-      // Skip if user is typing in an input/textarea
       const target = e.target as HTMLElement;
       if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
         return;
@@ -66,9 +123,7 @@ export function EditorCanvas() {
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 8,
-      },
+      activationConstraint: { distance: 8 },
     }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
@@ -78,14 +133,11 @@ export function EditorCanvas() {
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event;
-
       if (!over || active.id === over.id || !selectedModuleId || !selectedLessonId || !currentLesson) {
         return;
       }
-
       const oldIndex = currentLesson.blocks.findIndex((b) => b.id === active.id);
       const newIndex = currentLesson.blocks.findIndex((b) => b.id === over.id);
-
       if (oldIndex !== -1 && newIndex !== -1) {
         reorderBlocks(selectedModuleId, selectedLessonId, oldIndex, newIndex);
       }
@@ -93,105 +145,230 @@ export function EditorCanvas() {
     [selectedModuleId, selectedLessonId, currentLesson, reorderBlocks],
   );
 
-  // No module selected
+  const handleMoveBlock = useCallback(
+    (fromIndex: number, toIndex: number) => {
+      if (!selectedModuleId || !selectedLessonId) return;
+      reorderBlocks(selectedModuleId, selectedLessonId, fromIndex, toIndex);
+    },
+    [selectedModuleId, selectedLessonId, reorderBlocks],
+  );
+
+  const handleInsertBlock = useCallback(
+    (type: BlockType) => {
+      if (!selectedModuleId || !selectedLessonId) return;
+      const block = createDefaultBlock(type);
+      addBlock(selectedModuleId, selectedLessonId, block);
+      setInsertAfterIndex(null);
+    },
+    [selectedModuleId, selectedLessonId, addBlock],
+  );
+
+  // ── Empty states ─────────────────────────────────────────
   if (!selectedModuleId || !currentModule) {
     return (
-      <div className="flex h-full items-center justify-center p-8">
-        <div className="text-center">
-          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
-            <Plus className="h-8 w-8 text-muted-foreground" />
-          </div>
-          <h3 className="text-lg font-medium text-foreground">No module selected</h3>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Select or create a module to start
-          </p>
-        </div>
-      </div>
+      <EmptyState
+        icon={<Sparkles className="h-8 w-8 text-primary/60" />}
+        title="No module selected"
+        description="Select a module from the sidebar or create a new one to start building."
+      />
     );
   }
 
-  // No lesson selected
   if (!selectedLessonId || !currentLesson) {
     return (
-      <div className="flex h-full items-center justify-center p-8">
-        <div className="text-center">
-          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
-            <Plus className="h-8 w-8 text-muted-foreground" />
-          </div>
-          <h3 className="text-lg font-medium text-foreground">No lesson selected</h3>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Select or create a lesson to start
-          </p>
-        </div>
-      </div>
+      <EmptyState
+        icon={<Plus className="h-8 w-8 text-primary/60" />}
+        title="No lesson selected"
+        description="Select a lesson from the sidebar to start editing its content blocks."
+      />
     );
   }
 
   const blocks = currentLesson.blocks;
   const blockIds = blocks.map((b) => b.id);
 
-  // Empty lesson - no blocks yet
   if (blocks.length === 0) {
     return (
       <div className="flex h-full flex-col items-center justify-center p-8">
-        <div className="text-center">
-          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
-            <Plus className="h-8 w-8 text-muted-foreground" />
+        <div className="text-center max-w-sm">
+          <div className="mx-auto mb-5 flex h-20 w-20 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/10 to-primary/5 border border-primary/10">
+            <Plus className="h-8 w-8 text-primary/60" />
           </div>
-          <h3 className="text-lg font-medium text-foreground">No blocks yet</h3>
-          <p className="mt-1 mb-4 text-sm text-muted-foreground">
-            Add your first block to start building this lesson
+          <h3 className="text-lg font-semibold text-foreground">Start building</h3>
+          <p className="mt-1.5 mb-6 text-sm text-muted-foreground">
+            Add blocks to create an engaging lesson. Mix text, images, interactive elements, and quizzes.
           </p>
-          <Button
-            variant="outline"
-            size="lg"
-            className="gap-2"
-            onClick={() => {
-              // BlockToolbar handles block creation - this button acts as a visual cue.
-              // Scroll to the toolbar at the bottom or trigger block menu.
-              const toolbar = document.getElementById('block-toolbar');
-              toolbar?.scrollIntoView({ behavior: 'smooth' });
-              toolbar?.focus();
-            }}
-          >
-            <Plus className="h-4 w-4" />
-            Add your first block
-          </Button>
+          <BlockToolbar onInsertBlock={handleInsertBlock} />
         </div>
       </div>
     );
   }
 
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-3 p-6">
+    <div className="mx-auto w-full max-w-4xl space-y-1 px-6 py-8">
+      {/* Lesson header breadcrumb */}
+      <div className="mb-6 flex items-center gap-3">
+        <div className="flex-1">
+          <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1">
+            {currentModule.title}
+          </p>
+          <h2 className="text-lg font-semibold text-foreground">
+            {currentLesson.title}
+          </h2>
+        </div>
+        <div className="text-xs text-muted-foreground bg-muted/60 rounded-full px-3 py-1 border border-border/40">
+          {blocks.length} {blocks.length === 1 ? 'block' : 'blocks'}
+        </div>
+      </div>
+
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
         onDragEnd={handleDragEnd}
       >
         <SortableContext items={blockIds} strategy={verticalListSortingStrategy}>
-          {blocks.map((block) => (
-            <BlockWrapper
-              key={block.id}
-              id={block.id}
-              isSelected={selectedBlockId === block.id}
-              onSelect={() => selectBlock(block.id)}
-              onDelete={() => deleteBlock(selectedModuleId, selectedLessonId, block.id)}
-              onDuplicate={() => duplicateBlock(selectedModuleId, selectedLessonId, block.id)}
-            >
-              <BlockEditor
-                block={block}
-                onChange={(data) =>
-                  updateBlock(selectedModuleId, selectedLessonId, block.id, data)
+          {blocks.map((block, index) => (
+            <React.Fragment key={block.id}>
+              {/* Inline "+" insertion between blocks */}
+              {index > 0 && (
+                <InlineInsertButton
+                  isOpen={insertAfterIndex === index - 1}
+                  onToggle={() =>
+                    setInsertAfterIndex(
+                      insertAfterIndex === index - 1 ? null : index - 1
+                    )
+                  }
+                  onInsert={handleInsertBlock}
+                />
+              )}
+
+              <BlockWrapper
+                id={block.id}
+                isSelected={selectedBlockId === block.id}
+                blockType={block.type}
+                blockIndex={index}
+                totalBlocks={blocks.length}
+                onSelect={() => selectBlock(block.id)}
+                onDelete={() =>
+                  deleteBlock(selectedModuleId, selectedLessonId, block.id)
                 }
-              />
-            </BlockWrapper>
+                onDuplicate={() =>
+                  duplicateBlock(selectedModuleId, selectedLessonId, block.id)
+                }
+                onMoveUp={
+                  index > 0
+                    ? () => handleMoveBlock(index, index - 1)
+                    : undefined
+                }
+                onMoveDown={
+                  index < blocks.length - 1
+                    ? () => handleMoveBlock(index, index + 1)
+                    : undefined
+                }
+              >
+                <BlockEditor
+                  block={block}
+                  onChange={(data) =>
+                    updateBlock(selectedModuleId, selectedLessonId, block.id, data)
+                  }
+                />
+              </BlockWrapper>
+            </React.Fragment>
           ))}
         </SortableContext>
       </DndContext>
 
-      {/* Block toolbar area at the bottom for adding new blocks */}
-      <div id="block-toolbar" tabIndex={-1} />
+      {/* Bottom "Add Block" area */}
+      <div className="pt-4 flex justify-center">
+        <BlockToolbar onInsertBlock={handleInsertBlock} />
+      </div>
+
+      <div className="h-32" />
+    </div>
+  );
+}
+
+// ============================================================
+// EMPTY STATE COMPONENT
+// ============================================================
+
+function EmptyState({
+  icon,
+  title,
+  description,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex h-full items-center justify-center p-8">
+      <div className="text-center max-w-xs">
+        <div className="mx-auto mb-4 flex h-20 w-20 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/10 to-primary/5 border border-primary/10">
+          {icon}
+        </div>
+        <h3 className="text-lg font-semibold text-foreground">{title}</h3>
+        <p className="mt-1.5 text-sm text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================
+// INLINE INSERT BUTTON (Notion-style "+" between blocks)
+// ============================================================
+
+function InlineInsertButton({
+  isOpen,
+  onToggle,
+  onInsert,
+}: {
+  isOpen: boolean;
+  onToggle: () => void;
+  onInsert: (type: BlockType) => void;
+}) {
+  return (
+    <div
+      className={cn(
+        'group/insert relative flex items-center justify-center transition-all',
+        isOpen ? 'py-2' : 'py-0.5',
+      )}
+    >
+      {/* Horizontal line */}
+      <div
+        className={cn(
+          'absolute inset-x-0 top-1/2 h-px transition-colors duration-200',
+          isOpen
+            ? 'bg-primary/30'
+            : 'bg-transparent group-hover/insert:bg-border',
+        )}
+      />
+
+      {/* "+" circle */}
+      <button
+        type="button"
+        onClick={onToggle}
+        className={cn(
+          'relative z-10 flex h-6 w-6 items-center justify-center rounded-full border transition-all duration-200',
+          isOpen
+            ? 'bg-primary text-primary-foreground border-primary shadow-md scale-110'
+            : 'bg-background text-muted-foreground border-border/60 opacity-0 group-hover/insert:opacity-100 hover:border-primary hover:text-primary hover:shadow-sm',
+        )}
+      >
+        <Plus
+          className={cn(
+            'h-3.5 w-3.5 transition-transform duration-200',
+            isOpen && 'rotate-45',
+          )}
+        />
+      </button>
+
+      {/* Popover-style insert menu */}
+      {isOpen && (
+        <div className="absolute top-full z-30 mt-1">
+          <BlockToolbar onInsertBlock={onInsert} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/authoring/EditorHeader.tsx
+++ b/src/components/authoring/EditorHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   ArrowLeft,
@@ -11,24 +11,24 @@ import {
   Save,
   Upload,
   Loader2,
+  Check,
+  Keyboard,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { useEditorStore } from '@/stores/editor.store';
 import { cn } from '@/lib/utils';
-
-// ============================================================
-// PROPS
-// ============================================================
 
 interface EditorHeaderProps {
   courseTitle: string;
   onSave: () => Promise<void>;
   onPublish: () => Promise<void>;
 }
-
-// ============================================================
-// EDITOR HEADER COMPONENT
-// ============================================================
 
 export function EditorHeader({
   courseTitle,
@@ -49,6 +49,15 @@ export function EditorHeader({
 
   const [isSaveLoading, setIsSaveLoading] = useState(false);
   const [isPublishLoading, setIsPublishLoading] = useState(false);
+  const [showSavedFeedback, setShowSavedFeedback] = useState(false);
+
+  // Show "Saved" feedback briefly after a successful save
+  useEffect(() => {
+    if (showSavedFeedback) {
+      const t = setTimeout(() => setShowSavedFeedback(false), 2000);
+      return () => clearTimeout(t);
+    }
+  }, [showSavedFeedback]);
 
   const handleBack = () => {
     router.push('/dashboard/courses');
@@ -59,6 +68,7 @@ export function EditorHeader({
     setIsSaveLoading(true);
     try {
       await onSave();
+      setShowSavedFeedback(true);
     } finally {
       setIsSaveLoading(false);
     }
@@ -78,121 +88,156 @@ export function EditorHeader({
   const publishingInProgress = isPublishing || isPublishLoading;
 
   return (
-    <header className="flex h-14 items-center justify-between border-b border-border bg-background px-4">
-      {/* Left section: Back + Title + Dirty indicator */}
-      <div className="flex items-center gap-3">
-        {/* Back button */}
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handleBack}
-          className="gap-1.5"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          <span className="hidden sm:inline">Back</span>
-        </Button>
+    <TooltipProvider delayDuration={300}>
+      <header className="flex h-14 items-center justify-between border-b border-border/60 bg-background/95 backdrop-blur-sm px-4">
+        {/* Left: Back + Title + Status */}
+        <div className="flex items-center gap-2.5 min-w-0">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleBack}
+                className="h-8 w-8 shrink-0"
+              >
+                <ArrowLeft className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              Back to courses
+            </TooltipContent>
+          </Tooltip>
 
-        {/* Separator */}
-        <div className="h-6 w-px bg-border" />
+          <div className="h-5 w-px bg-border/60 shrink-0" />
 
-        {/* Course title */}
-        <h1 className="max-w-[200px] truncate text-sm font-semibold text-foreground sm:max-w-[300px]">
-          {courseTitle}
-        </h1>
+          <h1 className="truncate text-sm font-semibold text-foreground max-w-[200px] sm:max-w-[300px]">
+            {courseTitle}
+          </h1>
 
-        {/* Unsaved changes indicator */}
-        {isDirty && (
-          <div className="flex items-center gap-1.5 text-xs text-orange-500">
-            <span className="inline-block h-2 w-2 rounded-full bg-orange-500" />
-            <span className="hidden sm:inline">Unsaved changes</span>
+          {/* Save status */}
+          <div className="shrink-0">
+            {savingInProgress ? (
+              <span className="flex items-center gap-1.5 text-xs text-muted-foreground animate-pulse">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                <span className="hidden sm:inline">Saving...</span>
+              </span>
+            ) : showSavedFeedback ? (
+              <span className="flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                <Check className="h-3 w-3" />
+                <span className="hidden sm:inline">Saved</span>
+              </span>
+            ) : isDirty ? (
+              <span className="flex items-center gap-1.5 text-xs text-amber-500">
+                <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />
+                <span className="hidden sm:inline">Unsaved</span>
+              </span>
+            ) : null}
           </div>
-        )}
-      </div>
+        </div>
 
-      {/* Right section: Undo/Redo + Preview + Save + Publish */}
-      <div className="flex items-center gap-1.5">
-        {/* Undo */}
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={undo}
-          disabled={undoStack.length === 0}
-          title="Undo"
-          className="h-8 w-8"
-        >
-          <Undo2 className="h-4 w-4" />
-        </Button>
+        {/* Right: Actions */}
+        <div className="flex items-center gap-1">
+          {/* Undo */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={undo}
+                disabled={undoStack.length === 0}
+                className="h-8 w-8"
+              >
+                <Undo2 className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              Undo <kbd className="ml-1 rounded bg-muted px-1 py-0.5 text-[10px] font-mono">Ctrl+Z</kbd>
+            </TooltipContent>
+          </Tooltip>
 
-        {/* Redo */}
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={redo}
-          disabled={redoStack.length === 0}
-          title="Redo"
-          className="h-8 w-8"
-        >
-          <Redo2 className="h-4 w-4" />
-        </Button>
+          {/* Redo */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={redo}
+                disabled={redoStack.length === 0}
+                className="h-8 w-8"
+              >
+                <Redo2 className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              Redo <kbd className="ml-1 rounded bg-muted px-1 py-0.5 text-[10px] font-mono">Ctrl+Shift+Z</kbd>
+            </TooltipContent>
+          </Tooltip>
 
-        {/* Separator */}
-        <div className="mx-1 h-6 w-px bg-border" />
+          <div className="mx-1.5 h-5 w-px bg-border/60" />
 
-        {/* Preview toggle */}
-        <Button
-          variant={previewMode ? 'secondary' : 'ghost'}
-          size="sm"
-          onClick={togglePreview}
-          className="gap-1.5"
-          title={previewMode ? 'Exit preview' : 'Preview'}
-        >
-          {previewMode ? (
-            <EyeOff className="h-4 w-4" />
-          ) : (
-            <Eye className="h-4 w-4" />
-          )}
-          <span className="hidden sm:inline">Preview</span>
-        </Button>
+          {/* Preview */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={previewMode ? 'secondary' : 'ghost'}
+                size="sm"
+                onClick={togglePreview}
+                className="gap-1.5 h-8"
+              >
+                {previewMode ? (
+                  <EyeOff className="h-3.5 w-3.5" />
+                ) : (
+                  <Eye className="h-3.5 w-3.5" />
+                )}
+                <span className="hidden sm:inline text-xs">
+                  {previewMode ? 'Exit Preview' : 'Preview'}
+                </span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              {previewMode ? 'Exit preview mode' : 'Preview as learner'}
+            </TooltipContent>
+          </Tooltip>
 
-        {/* Separator */}
-        <div className="mx-1 h-6 w-px bg-border" />
+          <div className="mx-1.5 h-5 w-px bg-border/60" />
 
-        {/* Save button */}
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleSave}
-          disabled={savingInProgress}
-          className="gap-1.5"
-        >
-          {savingInProgress ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Save className="h-4 w-4" />
-          )}
-          <span className="hidden sm:inline">
-            {savingInProgress ? 'Saving...' : 'Save'}
-          </span>
-        </Button>
+          {/* Save */}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleSave}
+            disabled={savingInProgress || !isDirty}
+            className="gap-1.5 h-8 text-xs"
+          >
+            {savingInProgress ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Save className="h-3.5 w-3.5" />
+            )}
+            <span className="hidden sm:inline">
+              {savingInProgress ? 'Saving' : 'Save'}
+            </span>
+          </Button>
 
-        {/* Publish button */}
-        <Button
-          variant="success"
-          size="sm"
-          onClick={handlePublish}
-          disabled={publishingInProgress || !isDirty || savingInProgress}
-          className="gap-1.5"
-        >
-          {publishingInProgress ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Upload className="h-4 w-4" />
-          )}
-          <span className="hidden sm:inline">
-            {publishingInProgress ? 'Publishing...' : 'Publish'}
-          </span>
-        </Button>
-      </div>
-    </header>
+          {/* Publish */}
+          <Button
+            variant="default"
+            size="sm"
+            onClick={handlePublish}
+            disabled={publishingInProgress || !isDirty || savingInProgress}
+            className="gap-1.5 h-8 text-xs bg-emerald-600 hover:bg-emerald-700 text-white"
+          >
+            {publishingInProgress ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Upload className="h-3.5 w-3.5" />
+            )}
+            <span className="hidden sm:inline">
+              {publishingInProgress ? 'Publishing' : 'Publish'}
+            </span>
+          </Button>
+        </div>
+      </header>
+    </TooltipProvider>
   );
 }

--- a/src/components/authoring/ModuleSidebar.tsx
+++ b/src/components/authoring/ModuleSidebar.tsx
@@ -7,6 +7,7 @@ import {
   Plus,
   X,
   FileText,
+  FolderOpen,
   Folder,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -37,7 +38,6 @@ function InlineEdit({ value, onSave, className }: InlineEditProps) {
     }
   }, [isEditing]);
 
-  // Keep editValue in sync when value changes externally
   useEffect(() => {
     if (!isEditing) {
       setEditValue(value);
@@ -74,7 +74,7 @@ function InlineEdit({ value, onSave, className }: InlineEditProps) {
         onChange={(e) => setEditValue(e.target.value)}
         onBlur={handleSave}
         onKeyDown={handleKeyDown}
-        className="h-6 px-1 py-0 text-xs"
+        className="h-6 px-1.5 py-0 text-xs border-primary/40 bg-primary/5 focus-visible:ring-primary/20"
       />
     );
   }
@@ -83,7 +83,7 @@ function InlineEdit({ value, onSave, className }: InlineEditProps) {
     <span
       onDoubleClick={() => setIsEditing(true)}
       className={cn('cursor-default truncate select-none', className)}
-      title="Double-click to rename"
+      title={`${value} — Double-click to rename`}
     >
       {value}
     </span>
@@ -107,16 +107,10 @@ export function ModuleSidebar() {
   const selectModule = useEditorStore((s) => s.selectModule);
   const selectLesson = useEditorStore((s) => s.selectLesson);
 
-  // Track which modules are expanded/collapsed
   const [expandedModules, setExpandedModules] = useState<Set<string>>(
     () => new Set(modules.map((m) => m.id)),
   );
 
-  // Track which item is being hovered for showing delete button
-  const [hoveredModuleId, setHoveredModuleId] = useState<string | null>(null);
-  const [hoveredLessonId, setHoveredLessonId] = useState<string | null>(null);
-
-  // Auto-expand newly added modules
   useEffect(() => {
     setExpandedModules((prev) => {
       const next = new Set(prev);
@@ -191,119 +185,141 @@ export function ModuleSidebar() {
   );
 
   return (
-    <div className="flex h-full w-64 flex-col border-e border-border bg-muted/30">
+    <div className="flex h-full w-72 flex-col border-e border-border/60 bg-muted/20">
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-border px-3 py-3">
-        <h2 className="text-sm font-semibold text-foreground">
+      <div className="flex items-center justify-between border-b border-border/60 px-4 py-3">
+        <h2 className="text-xs font-semibold text-foreground uppercase tracking-wider">
           Course Structure
         </h2>
         <Button
           variant="ghost"
           size="sm"
           onClick={handleAddModule}
-          className="h-7 gap-1 px-2 text-xs"
+          className="h-7 gap-1 px-2 text-xs text-primary hover:text-primary hover:bg-primary/10"
         >
           <Plus className="h-3.5 w-3.5" />
-          Add Module
+          Module
         </Button>
       </div>
 
       {/* Module Tree */}
       <ScrollArea className="flex-1">
-        <div className="p-2">
+        <div className="p-2.5 space-y-1">
           {modules.length === 0 && (
-            <div className="px-3 py-8 text-center text-xs text-muted-foreground">
-              No modules yet. Click &quot;Add Module&quot; to get started.
+            <div className="flex flex-col items-center justify-center px-4 py-12 text-center">
+              <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-xl bg-primary/5 border border-primary/10">
+                <FolderOpen className="h-5 w-5 text-primary/50" />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                No modules yet.
+              </p>
+              <button
+                onClick={handleAddModule}
+                className="mt-2 text-xs font-medium text-primary hover:underline"
+              >
+                Create your first module
+              </button>
             </div>
           )}
 
           {modules.map((module) => {
             const isExpanded = expandedModules.has(module.id);
-            const isModuleHovered = hoveredModuleId === module.id;
+            const isModuleSelected =
+              selectedModuleId === module.id && !selectedLessonId;
+            const lessonCount = module.lessons.length;
 
             return (
-              <div key={module.id} className="mb-1">
+              <div key={module.id}>
                 {/* Module Row */}
                 <div
                   className={cn(
-                    'group flex items-center gap-1 rounded-md px-2 py-1.5 text-sm transition-colors',
-                    'hover:bg-muted cursor-pointer',
-                    selectedModuleId === module.id &&
-                      !selectedLessonId &&
-                      'bg-primary/10 text-primary',
+                    'group/mod flex items-center gap-1.5 rounded-lg px-2.5 py-2 text-sm transition-all duration-150 cursor-pointer',
+                    isModuleSelected
+                      ? 'bg-primary/10 text-primary'
+                      : 'hover:bg-muted text-foreground',
                   )}
                   onClick={() => toggleModuleExpanded(module.id)}
-                  onMouseEnter={() => setHoveredModuleId(module.id)}
-                  onMouseLeave={() => setHoveredModuleId(null)}
                 >
-                  {/* Expand/Collapse chevron */}
-                  {isExpanded ? (
-                    <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                  ) : (
-                    <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                  )}
-
-                  {/* Folder icon */}
-                  <Folder className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-
-                  {/* Order number */}
-                  <span className="shrink-0 text-xs text-muted-foreground">
-                    {module.order + 1}.
+                  {/* Expand chevron */}
+                  <span className="shrink-0 text-muted-foreground">
+                    {isExpanded ? (
+                      <ChevronDown className="h-4 w-4" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4" />
+                    )}
                   </span>
 
-                  {/* Module title (inline editable) */}
+                  {/* Folder icon */}
+                  {isExpanded ? (
+                    <FolderOpen className="h-4 w-4 shrink-0 text-primary/60" />
+                  ) : (
+                    <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  )}
+
+                  {/* Module title */}
                   <InlineEdit
                     value={module.title}
                     onSave={(newTitle) =>
                       handleModuleRename(module.id, newTitle)
                     }
-                    className="flex-1 text-sm"
+                    className="flex-1 text-sm font-medium"
                   />
 
-                  {/* Delete button (visible on hover) */}
-                  {isModuleHovered && (
-                    <button
-                      onClick={(e) => handleDeleteModule(e, module.id)}
-                      className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                      title="Delete module"
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  )}
+                  {/* Lesson count badge */}
+                  <span
+                    className={cn(
+                      'shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums transition-colors',
+                      isModuleSelected
+                        ? 'bg-primary/20 text-primary'
+                        : 'bg-muted text-muted-foreground',
+                    )}
+                  >
+                    {lessonCount}
+                  </span>
+
+                  {/* Delete button */}
+                  <button
+                    onClick={(e) => handleDeleteModule(e, module.id)}
+                    className="shrink-0 rounded-md p-1 text-muted-foreground transition-all opacity-0 group-hover/mod:opacity-100 hover:bg-destructive/10 hover:text-destructive"
+                    title="Delete module"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
                 </div>
 
-                {/* Lessons (visible when module is expanded) */}
+                {/* Lessons */}
                 {isExpanded && (
-                  <div className="ms-4 mt-0.5 border-s border-border ps-2">
+                  <div className="ms-4 mt-0.5 border-s-2 border-border/40 ps-2 space-y-0.5">
                     {module.lessons.map((lesson) => {
                       const isSelected =
                         selectedModuleId === module.id &&
                         selectedLessonId === lesson.id;
-                      const isLessonHovered = hoveredLessonId === lesson.id;
+                      const blockCount = lesson.blocks?.length ?? 0;
 
                       return (
                         <div
                           key={lesson.id}
                           className={cn(
-                            'group flex items-center gap-1.5 rounded-md px-2 py-1 text-sm transition-colors',
-                            'hover:bg-muted cursor-pointer',
-                            isSelected && 'bg-primary/10 text-primary',
+                            'group/lesson flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm transition-all duration-150 cursor-pointer',
+                            isSelected
+                              ? 'bg-primary/10 text-primary font-medium'
+                              : 'hover:bg-muted text-foreground/80',
                           )}
                           onClick={() =>
                             handleLessonClick(module.id, lesson.id)
                           }
-                          onMouseEnter={() => setHoveredLessonId(lesson.id)}
-                          onMouseLeave={() => setHoveredLessonId(null)}
                         >
                           {/* Lesson icon */}
-                          <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                          <FileText
+                            className={cn(
+                              'h-3.5 w-3.5 shrink-0',
+                              isSelected
+                                ? 'text-primary'
+                                : 'text-muted-foreground',
+                            )}
+                          />
 
-                          {/* Order number */}
-                          <span className="shrink-0 text-xs text-muted-foreground">
-                            {lesson.order + 1}.
-                          </span>
-
-                          {/* Lesson title (inline editable) */}
+                          {/* Lesson title */}
                           <InlineEdit
                             value={lesson.title}
                             onSave={(newTitle) =>
@@ -316,31 +332,36 @@ export function ModuleSidebar() {
                             className="flex-1 text-xs"
                           />
 
+                          {/* Block count */}
+                          {blockCount > 0 && (
+                            <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">
+                              {blockCount}
+                            </span>
+                          )}
+
                           {/* Selected indicator */}
                           {isSelected && (
                             <div className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
                           )}
 
-                          {/* Delete button (visible on hover) */}
-                          {isLessonHovered && (
-                            <button
-                              onClick={(e) =>
-                                handleDeleteLesson(e, module.id, lesson.id)
-                              }
-                              className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                              title="Delete lesson"
-                            >
-                              <X className="h-3 w-3" />
-                            </button>
-                          )}
+                          {/* Delete */}
+                          <button
+                            onClick={(e) =>
+                              handleDeleteLesson(e, module.id, lesson.id)
+                            }
+                            className="shrink-0 rounded-md p-0.5 text-muted-foreground transition-all opacity-0 group-hover/lesson:opacity-100 hover:bg-destructive/10 hover:text-destructive"
+                            title="Delete lesson"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
                         </div>
                       );
                     })}
 
-                    {/* Add Lesson button */}
+                    {/* Add Lesson */}
                     <button
                       onClick={() => handleAddLesson(module.id)}
-                      className="mt-0.5 flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      className="mt-0.5 flex w-full items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-muted-foreground transition-all hover:bg-primary/5 hover:text-primary"
                     >
                       <Plus className="h-3 w-3" />
                       Add Lesson


### PR DESCRIPTION
…earch, visual polish

- BlockWrapper: floating action toolbar with tooltips, block type labels, move up/down controls, drag handle improvements, dropdown more menu
- EditorCanvas: Notion-style inline "+" insertion between blocks, lesson breadcrumb header, createDefaultBlock helper, improved empty states
- EditorHeader: save feedback animation (Saved/Unsaved states), keyboard shortcut hints in tooltips (Ctrl+Z, Ctrl+Shift+Z), backdrop blur
- ModuleSidebar: wider layout (w-72), lesson count badges, block counts, folder open/close icons, improved empty state with CTA
- BlockToolbar: search with keyword matching, block descriptions, polished grid with icon containers, list view for search results

https://claude.ai/code/session_01R5WhtkpDFAraV5jCFAPRoU